### PR TITLE
Fix cross-stream memory visibility race on DGX spark Blackwell (sm_121)

### DIFF
--- a/libs/sof/sof_mono_gpu.cpp
+++ b/libs/sof/sof_mono_gpu.cpp
@@ -114,6 +114,10 @@ void MonoSOFGPU::track(const ImageAndSource &curr_image, const ImageContextPtr &
 
   curr_image.image->build_gpu_image_pyramid(curr_image.source, sof_settings_.box3_prefilter, stream.get_stream());
   curr_image.image->build_gpu_gradient_pyramid(false, stream.get_stream());
+  // Sync after pyramid build to ensure GPU memory is visible to other streams.
+  // Required on Blackwell (sm_121) where cross-stream memory visibility is not
+  // guaranteed without explicit synchronization.
+  cudaStreamSynchronize(stream.get_stream());
 
   curr_img_ = curr_image.image;
 

--- a/libs/sof/sof_multicamera_base.cpp
+++ b/libs/sof/sof_multicamera_base.cpp
@@ -74,6 +74,11 @@ bool MultiSOFBase::trackNextFrame(const Sources& curr_sources, Images& curr_imag
     return false;
   }
 
+  // Ensure all mono-stream GPU work (pyramid builds, LK tracking) is complete
+  // before reading results. Required for cross-stream memory visibility on
+  // architectures like Blackwell (sm_121).
+  cudaDeviceSynchronize();
+
   MulticamTracksVector primary_tracks;
   for (auto& sof : mono_sof_) {
     TRACE_EVENT ev1 = profiler_domain_.trace_event("mono finish", profiler_color_);
@@ -90,6 +95,11 @@ bool MultiSOFBase::trackNextFrame(const Sources& curr_sources, Images& curr_imag
 
   if (is_keyframe(primary_tracks, current_time_ns)) {
     TRACE_EVENT ev1 = profiler_domain_.trace_event("prim->sec", profiler_color_);
+    // Ensure all mono-stream GPU work (pyramid builds, feature detection) is fully
+    // visible before launching stereo tracking on separate streams. Without this,
+    // cross-stream memory visibility is not guaranteed on some GPU architectures
+    // (e.g. Blackwell sm_121), leading to CUDA error 700 after ~200 frames.
+    cudaDeviceSynchronize();
     StartKeyframe();
     size_t num_prim_to_sec_tracks = 0;
     const auto& primary_cams = fid_.primary_cameras();


### PR DESCRIPTION
## Summary

Fix CUDA error 700 (illegal memory access) on Blackwell GPUs (sm_121) in multi-camera visual odometry. The crash is deterministic at ~200 frames with 6-camera (3 stereo pair) configurations.

## Root Cause

`MonoSOFGPU::track()` builds image pyramids and gradient pyramids on per-camera CUDA streams. These pyramids are later read by stereo pair tracking (`LaunchTrackingPrimaryToSecondary`) on different per-pair streams, without explicit cross-stream synchronization.

On pre-Blackwell GPUs, the implicit memory ordering happened to work. On Blackwell (sm_121), the stricter memory model requires explicit synchronization for cross-stream memory visibility.

## Fix

- **`sof_mono_gpu.cpp`**: Add `cudaStreamSynchronize` after pyramid + gradient build to ensure GPU memory is visible to other streams
- **`sof_multicamera_base.cpp`**: Add `cudaDeviceSynchronize` barriers before mono finish and stereo launch phases

## Testing

Tested on NVIDIA GB10 (aarch64, CUDA 13, sm_121) with a 6-camera rig (3 stereo pairs), 8075 frames:

| Variant | Result |
|---------|--------|
| No fix | Crash at frame ~209 |
| `cudaDeviceSynchronize` before stereo launch only | Crash at frame ~1053 |
| + `cudaDeviceSynchronize` before mono finish | Crash at frame ~2407 |
| + `cudaStreamSynchronize` after mono pyramid build | **All 8075 frames pass** |
| `CUDA_LAUNCH_BLOCKING=1` (reference) | All frames pass (confirms async race) |
| `compute-sanitizer` (reference) | All frames pass (serialized execution) |

## Notes

This fix is conservative — `cudaStreamSynchronize` per mono stream and `cudaDeviceSynchronize` at phase boundaries. A more targeted approach using `cudaEvent` + `cudaStreamWaitEvent` could preserve more parallelism but requires deeper changes to the Stream/ImageContext ownership model.