### PR TITLE
[clean] Align docs with current APIs and main branch 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .cache/
 __pycache__/
 *.egg-info
-build/
+build*/
 compile_commands.json
 dataset/
 /datasets/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-json
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
-      - id: no-commit-to-branch    # Prevents committing to master
+      - id: no-commit-to-branch    # Prevents committing to main
       - id: mixed-line-ending
         args:
           - --fix=lf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: check-json
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
-      - id: no-commit-to-branch    # Prevents committing to main
+      - id: no-commit-to-branch    # Prevents committing to master
       - id: mixed-line-ending
         args:
           - --fix=lf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Load-bearing rules:
 - Don't put implementation details in `cuvslam2.h`; it is the public C++ API boundary
 - Don't use non-ABI-stable types (`std::string`, `std::map`, etc.) in `cuvslam2.h`; `std::vector` is the explicit exception. Otherwise, use `std::string_view`, raw pointers with a count, or plain structs of primitive types only
 - Don't mix different `CMAKE_BUILD_TYPE` values in the same `CUVSLAM_DST_DIR`
-- Don't commit directly to `master` — the pre-commit hook blocks it
+- Don't commit directly to `main` — the pre-commit hook blocks it
 - Don't skip pre-commit with `--no-verify` except to unblock a known false positive
 - Never run `git push`
 - Don't run `git commit` or `git commit --amend` without explicit user permission; always let the user review staged files before committing

--- a/DESIGN_CONCEPTS.md
+++ b/DESIGN_CONCEPTS.md
@@ -5,57 +5,69 @@ Follow these when making code changes or designing new features.
 
 ---
 
-## 1. Runtime parameter overrides are stateless — no setters
+## 1. Per-frame internal overrides are stateless — no setters
 
-**Rule:** Parameters that can change on a per-call basis must be passed explicitly through
-the runtime API. Do not use setter functions or mutable state on long-lived objects to
-change them.
+**Rule:** A low-level parameter that must vary for a single frame is passed explicitly to
+`Odometry::Track()` through `cuvslam::internal::Internals`. Do not mutate a long-lived
+object through a setter to change one frame.
+
+`Internals` is an unstable expert/development interface declared in
+`libs/cuvslam/cuvslam2_internal.h`. It is not part of the stable user-facing API. Normal
+applications should omit it and use the built-in defaults.
 
 **Why:** Setters create implicit shared state between frames. A parameter change made
 during one `Track()` call can silently bleed into the next frame if the setter mutates an
-object that is reused across calls. This makes behaviour hard to reason about, test, and
+object that is reused across calls. This makes behavior hard to reason about, test, and
 reproduce.
 
 **How it works in cuVSLAM:**
 
-The public `Track()` API accepts a `TrackOptions` struct that carries all per-frame
-overrides. `TrackOptions` has default values matching the construction-time config, so
-callers only specify what they actually want to change. Internally, this is converted to a
-`TrackPerFrameSettings` and threaded down the call stack without modifying any stored state.
+`Odometry::Track()` accepts an optional pointer to `Internals`. All fields have concrete
+defaults. `BuildTrackFrameSettings()` converts the selected values to
+`odom::TrackPerFrameSettings`, which is threaded down the call stack without modifying
+stored settings.
 
 ```cpp
-// Caller — override feature count for one frame only
-TrackOptions opts;
-opts.num_desired_tracks = 200;
-odometry.Track(images, {}, {}, opts);  // next call is unaffected
+// Expert/development use: override feature count for one frame only.
+cuvslam::internal::Internals internals;
+internals.num_desired_tracks = 200;
+odometry.Track(images, {}, {}, &internals);
+
+// The next call uses built-in defaults.
+odometry.Track(images);
 ```
 
-The stored `svo_settings` on `Odometry::Impl` is construction-time config only. It is
-never mutated after construction.
+Construction-time settings stored by `Odometry::Impl` are not changed by the per-frame
+override.
 
 **What to avoid:**
 
 ```cpp
-// BAD — setter mutates shared state, bleeds across frames
+// BAD — setter mutates shared state and can bleed across frames.
 odometry.SetNumDesiredTracks(200);
 odometry.Track(images);
 ```
 
-**Where to add new runtime parameters:**
+**Where to add a new per-frame internal parameter:**
 
-1. Add the field (with a default value) to `cuvslam::TrackOptions` in `cuvslam2.h`.
-2. Map it into `odom::TrackPerFrameSettings` in `BuildTrackFrameSettings()` in `cuvslam2.cpp`.
-3. Add the field to the appropriate sub-struct of `TrackPerFrameSettings` (`sof` or `kf`)
-   or add a new sub-struct for a new category (e.g. `pnp`, `icp`).
-4. Thread it through the call chain — do not store it.
+1. Confirm that the parameter is for expert/development tuning rather than a normal user
+   feature. Stable user-facing behavior belongs in `Odometry::Config` or another public API.
+2. Add the field and its default to `cuvslam::internal::Internals` in
+   `libs/cuvslam/cuvslam2_internal.h`.
+3. Map it into `odom::TrackPerFrameSettings` in `BuildTrackFrameSettings()` in
+   `libs/cuvslam/cuvslam2.cpp`.
+4. Add it to the appropriate `TrackPerFrameSettings` sub-struct (`sof`, `kf`, `pnp`,
+   `icp`, and so on), then thread it through the call chain without storing it.
+5. Update the Python binding and YAML loader only when the parameter must be available to
+   the corresponding development tools.
 
 ---
 
-## 2. Optionals belong at the top-level API; internal APIs always receive concrete values
+## 2. Resolve optional inputs at the API boundary
 
-**Rule:** `std::optional<T>` is appropriate at the public boundary (e.g. `Odometry::Track`)
-where a caller may genuinely not have a value. Internal APIs — everything below the public
-API boundary — must accept concrete values, not optionals.
+**Rule:** Optional input is appropriate at an API boundary where a caller may genuinely
+omit a value. Internal APIs below that boundary should receive concrete settings whenever
+possible.
 
 **Why:** Optionals at every layer of the call stack force every internal function to check
 `has_value()` before use. This is noise. Once the public API has resolved an optional to a
@@ -64,13 +76,20 @@ was ever absent.
 
 **How it works in cuVSLAM:**
 
-The public `Track()` API converts `TrackOptions` (which has defaults for everything) into
-`TrackPerFrameSettings` — a plain struct of concrete values. From that point on, no
-optional-checking is needed anywhere in the call chain.
+`Odometry::Track()` accepts a nullable `Internals` pointer. A null pointer selects
+`Internals{}`. `BuildTrackFrameSettings()` converts the result to a concrete
+`TrackPerFrameSettings`; lower layers do not need to know whether the caller supplied an
+override.
+
+`Internals::kf_override_frame_selection` is an intentional tri-state exception: unset uses
+automatic keyframe selection, `true` forces a keyframe, and `false` forces a non-keyframe.
+Resolve such values at the first layer that has enough context, rather than propagating
+optionality farther down the call stack.
 
 ```text
-TrackOptions{} (public, fields have defaults)
-    └─► BuildTrackFrameSettings() resolves to concrete TrackPerFrameSettings
+Internals* (null or expert/development overrides)
+    └─► Internals{} when null
+        └─► BuildTrackFrameSettings() produces TrackPerFrameSettings
             └─► IVisualOdometry::track(TrackPerFrameSettings&)   // no optional
                     └─► IMultiSOF::trackNextFrame(TrackPerFrameSettings&)  // no optional
                             └─► IMonoSOF::track(Settings&)  // no optional
@@ -133,16 +152,20 @@ struct TrackPerFrameSettings {
 
 ---
 
-## 4. Construction-time config vs runtime overrides
+## 4. Construction-time config vs internal runtime tuning
 
-Parameters fall into two categories:
+Settings fall into three categories:
 
-| Category | Example | Where it lives |
-|---|---|---|
-| **Construction-time** | GPU on/off, SBA mode, camera model | `Odometry::Config`, passed to constructor, stored in `svo_settings` |
-| **Per-frame runtime** | Feature count, border sizes, KF threshold | `TrackOptions`, passed to `Track()`, never stored |
+| Category | Example | Where it lives | Stability |
+|---|---|---|---|
+| **Construction-time configuration** | GPU on/off, odometry mode, data export | `Odometry::Config`, passed to the constructor | Public API |
+| **Per-frame internal tuning** | Feature count, border sizes, keyframe threshold | `internal::Internals`, passed to `Track()`, never stored | Unstable expert/development API |
+| **Persistent internal tuning** | SBA window and solver parameters | `internal::InternalParameter`, passed to `ApplyPersistentInternalParameters()` | Internal use only |
 
-If a parameter only makes sense to set once (at startup), it belongs in `Config`.
-If a parameter is useful to change per-frame (e.g. reduce features for a dark frame),
-it belongs in `TrackOptions`. When in doubt, start with `Config`; promote to `TrackOptions`
-when a concrete use case for per-frame variation exists.
+If a normal user must choose a value at startup, it belongs in `Config`. If a low-level
+development tool must vary a solver value per frame, it may belong in `Internals`. Values
+that intentionally persist after tracker construction use
+`ApplyPersistentInternalParameters()`.
+
+Do not expose a user-facing feature through `Internals` merely because it is convenient.
+Design a stable public API for that feature instead.

--- a/cuvslam-skills/cuvslam-onboard/SKILL.md
+++ b/cuvslam-skills/cuvslam-onboard/SKILL.md
@@ -243,11 +243,32 @@ tracker = cuvslam.Tracker(cuvslam.Rig(...), odom_cfg, slam_cfg)
 odom_pose, slam_pose = tracker.track(...)
 
 # Save map
-tracker.save_map("map/")
+def map_saved(success):
+    print(f"Map save {'succeeded' if success else 'failed'}")
+
+tracker.save_map("map/", map_saved)
 
 # Later: localize
 loc_settings = cuvslam.Tracker.SlamLocalizationSettings()
-tracker.localize_in_map("map/", timestamp, pose_hint, loc_settings)
+
+def localization_started():
+    print("Localization started")
+
+def localization_finished(pose, error_message):
+    if pose is not None:
+        print(f"Localized pose: {pose}")
+    else:
+        print(f"Localization failed: {error_message}")
+
+tracker.localize_in_map(
+    "map/",
+    timestamp,
+    pose_hint,
+    images,
+    loc_settings,
+    localization_started,
+    localization_finished,
+)
 ```
 
 See `examples/kitti/track_kitti_slam.py` for the complete workflow.

--- a/doc/load_map.md
+++ b/doc/load_map.md
@@ -21,9 +21,14 @@ Users who call **LocalizeInMap** must provide:
  *                    otherwise should be nullptr.
  * @see `Odometry::Track`
  * @throws std::invalid_argument if `gt_pose` is passed incorrectly
- * @return On success, the returned `Pose` is the rig pose estimated by SLAM
  */
-Pose Track(const Odometry::State& state, const Pose* gt_pose = nullptr);
+void Track(const Odometry::State& state, const Pose* gt_pose = nullptr);
+
+/**
+ * Get the current rig pose estimated by SLAM.
+ * Call this after Track() when the current pose is needed.
+ */
+Pose GetPose() const;
 ```
 
 ```cpp
@@ -85,20 +90,19 @@ interrupting real-time processing.
 **Scenarios**
 
 1. The user creates a `cuVSLAM::Slam` instance.
-2. The user feeds images via `Track`. This is a low-latency, real-time path (e.g. ~100 fps) with all camera frames. The
-   user
-   receives a real-time SLAM pose; the background thread runs LC search and map building.
+2. The user feeds images to `Odometry::Track`, passes each successful odometry state to `Slam::Track`, and obtains the
+   current SLAM pose with `Slam::GetPose`. This is a low-latency, real-time path (e.g. ~100 fps); the background thread
+   runs LC search and map building.
 3. At some point the user calls `SaveMap` (possibly from another thread). The map is written to disk by the background
    path; `Track` is not blocked by that work.
 4. At some point the user calls `LocalizeInMap` with image(s), timestamp, and prior. The background thread matches the
    images to the on-disk map. On success it drops the current map and replaces it with the loaded one. After that, the
-   next `Track` returns a pose in the new map.
+   first `GetPose` following the next `Track` reports a pose in the new map.
 
 **Camera moves during startup, then a map load is requested — what behavior do we support?**
 
-During the load, the user keeps calling `Track` for every frame and keeps receiving a pose. After the map is applied,
-the next
-`Track` returns the real robot pose in the loaded map.
+During the load, the user keeps calling `Track` for every frame and reading the current pose with `GetPose`. After the
+map is applied, the first `GetPose` following the next `Track` returns the real robot pose in the loaded map.
 
 **Example: car at 80 km/h, cuVSLAM starts, then 3 minutes / ~4 km later a map load is requested — what is expected?**
 

--- a/tools/cuvslam_api_launcher/README.md
+++ b/tools/cuvslam_api_launcher/README.md
@@ -41,25 +41,36 @@ To localize, the util will use the latest hint not later than current frame.
 
 ## Configuration via YAML File
 
-You can specify optional per-frame `track_options` using a YAML config file with the `--config` flag:
+You can specify optional per-frame `internals` and persistent expert parameters using a YAML config file with the
+`--config` flag:
 
 ```bash
 ./bin/cuvslam_api_launcher --config=api_config.yaml --edex=<edex file>
 ```
 
-Command-line flags will override values from the config file. See `api_config.yaml` for an example configuration with all supported options.
+Command-line flags will override values from the config file. See `api_config.yaml` for an example configuration with
+all supported options.
 
-**Note:** This launcher links the **`utils`** static library, which reads YAML and populates `Odometry::TrackOptions`, `Odometry::Config`, and `Slam::Config` structs directly. Python users can do the same via `cuvslam.utils.load_track_options_from_file`.
+**Note:** This launcher links the **`utils`** static library, which reads YAML and populates `Odometry::Config`,
+`Slam::Config`, and the unstable development-only `internal::Internals` struct. It applies `expert_params` once after
+tracker construction with `Odometry::ApplyPersistentInternalParameters()`. Normal applications should use the default
+internal parameters. Python development tools can load the same per-frame values with
+`cuvslam.utils.load_internals_from_file()`.
 
 ### Config File Structure
 
 ```yaml
-# Per-frame overrides passed to Odometry::Track(..., options); unset keys keep init-time defaults
-track_options:
+# Development-only per-frame overrides passed to Odometry::Track(..., &internals).
+# Unset keys retain the built-in defaults.
+internals:
   num_desired_tracks: 500
   kf_survivor_from_last: 40.0
   kf_max_timedelta_between_kfs_s: 20
-  # border_top, border_bottom, border_left, border_right, box3_prefilter, ransac_filter — see kitti_config.yaml
+
+# Development-only persistent parameters applied once after tracker construction.
+expert_params:
+  sba.num_sba_frames: 7
+  sba.num_sba_iterations: 7
 ```
 
 # Run tracker on EuRoC MAV Dataset (OBSOLETE)

--- a/tools/cuvslam_api_launcher/api_config.yaml
+++ b/tools/cuvslam_api_launcher/api_config.yaml
@@ -98,19 +98,20 @@ slam:
   throttling_time_ms: 0
 
 # =============================================================================
-# Per-frame Track Options (Odometry::TrackOptions), optional
+# Per-frame internal parameters (internal::Internals), optional
 # =============================================================================
-# Applied on every Odometry::Track() call; unset keys use TrackOptions defaults.
-# See src/examples/kitti/kitti_config.yaml for a fuller example.
+# Development-only, unstable parameters applied on every Odometry::Track() call.
+# Unset keys retain the built-in defaults.
 #
-track_options:
+internals:
   num_desired_tracks: 450
   kf_survivor_from_last: 41
 
 # =============================================================================
-# Expert SBA Parameters (ApplyExpertParameters), optional
+# Persistent internal parameters (ApplyPersistentInternalParameters), optional
 # =============================================================================
-# Applied once after tracker creation via ApplyExpertParameters().
+# Development-only parameters applied once after tracker creation via
+# Odometry::ApplyPersistentInternalParameters().
 # All values are forwarded as strings exactly as the API expects.
 # Command-line --expert_sba_* flags override these values.
 # mode and async are construction-time only; set them under odometry: above.


### PR DESCRIPTION
Remove stale TrackOptions and SLAM usage while updating branch guidance after the public repository migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated map-loading and localization guidance to use `GetPose()` after tracking.
  - Revised onboarding examples to demonstrate callback-based map saving and localization.
  - Clarified per-frame overrides, persistent tuning, and configuration behavior.

- **Configuration**
  - Replaced the documented `track_options` YAML section with `internals` for per-frame settings.
  - Added guidance for persistent expert parameters and updated sample configuration values.

- **Chores**
  - Updated branch-protection guidance and build-directory ignore rules to reflect current workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->