### PR TITLE
[fix] Document stable FPS for ZED RGB-D

### DIFF
--- a/examples/zed/live/README.md
+++ b/examples/zed/live/README.md
@@ -66,6 +66,10 @@ in [run_rgbd.py](run_rgbd.py).
 By default, the script uses the `sl.DEPTH_MODE.PERFORMANCE` depth mode of ZED SDK. For details on other depth modes and
 GPU acceleration, refer to the [official ZED documentation](https://www.stereolabs.com/docs/depth-sensing/using-depth).
 
+> **Tracking stability:** If the trajectory shows sudden jumps or the script reports frame drops at the default 30 FPS,
+> reduce `FPS` near the top of [run_rgbd.py](run_rgbd.py) from `30` to `15`. The lower frame rate can help the RGB-D
+> pipeline process frames consistently on systems that cannot keep up at 30 FPS.
+
 To run monocular-depth visual odometry, execute:
 
 ```bash


### PR DESCRIPTION
Advise lowering the live RGB-D camera rate when frame drops cause trajectory jumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for trajectory jumps and frame drops in the Monocular-Depth Visual Odometry example.
  * Recommends reducing the processing frame rate from 30 FPS to 15 FPS when needed for more consistent RGB-D performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->