### PR TITLE
[infra] Preserve nightly artifacts across reruns

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -272,6 +272,7 @@ jobs:
         with:
           path: output/dist/cuvslam-docs-${{ needs.check-changes.outputs.package_version }}.tar.gz
           archive: false
+          overwrite: true
           retention-days: 30
           if-no-files-found: error
 
@@ -294,6 +295,7 @@ jobs:
             output/eval/kpi_*.json
             output/eval/kpi_*.json.table
             output/eval/kpi_*.json.drift
+          overwrite: true
           retention-days: 1
           if-no-files-found: warn
 
@@ -303,6 +305,7 @@ jobs:
         with:
           name: ${{ env.EVAL_REPORT_ARTIFACT }}-${{ needs.check-changes.outputs.package_version }}-${{ matrix.platform }}-cuda${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}
           path: output/eval/stats/**/report_*.pdf
+          overwrite: true
           retention-days: 1
           if-no-files-found: warn
 
@@ -315,6 +318,7 @@ jobs:
             output/cpp-test-results.xml
             output/python-test-output.txt
             output/test-summary.txt
+          overwrite: true
           retention-days: 1
           if-no-files-found: warn
 
@@ -324,6 +328,7 @@ jobs:
         with:
           path: output/dist/cuvslam-cpp-${{ needs.check-changes.outputs.package_version }}-${{ matrix.platform }}-cuda${{ matrix.cuda }}-ubuntu${{ matrix.ubuntu }}.tar.gz
           archive: false
+          overwrite: true
           retention-days: 30
           if-no-files-found: error
 
@@ -333,6 +338,7 @@ jobs:
         with:
           path: output/wheel/*.whl
           archive: false
+          overwrite: true
           retention-days: 30
           if-no-files-found: error
 
@@ -534,6 +540,7 @@ jobs:
         with:
           name: test-results-${{ needs.check-changes.outputs.package_version }}
           path: consolidated/test-results/
+          overwrite: true
           retention-days: 30
           if-no-files-found: error
 
@@ -569,6 +576,7 @@ jobs:
         with:
           path: consolidated/cuvslam-evaluation-${{ needs.check-changes.outputs.package_version }}.tar.gz
           archive: false
+          overwrite: true
           retention-days: 30
           if-no-files-found: error
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -349,7 +349,9 @@ jobs:
       contents: read
     steps:
       - name: Download test result artifacts
-        if: needs.check-changes.outputs.should_build == 'true'
+        if: >-
+          needs.check-changes.outputs.should_build == 'true' &&
+          needs.build-and-test.result == 'success'
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -357,7 +359,9 @@ jobs:
           path: artifacts/test-results
 
       - name: Download KPI staging artifacts
-        if: needs.check-changes.outputs.should_build == 'true'
+        if: >-
+          needs.check-changes.outputs.should_build == 'true' &&
+          needs.build-and-test.result == 'success'
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -365,7 +369,9 @@ jobs:
           path: artifacts/kpis
 
       - name: Download evaluation report staging artifacts
-        if: needs.check-changes.outputs.should_build == 'true'
+        if: >-
+          needs.check-changes.outputs.should_build == 'true' &&
+          needs.build-and-test.result == 'success'
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
@@ -405,6 +411,17 @@ jobs:
           if [ "${{ needs.check-changes.outputs.should_build }}" != "true" ]; then
             {
               echo "Nightly skipped because there were no commits in the last 24 hours and the build was not forced."
+              echo ""
+            } >> "$REPORT"
+            echo "has_test_results=false" >> "$GITHUB_OUTPUT"
+            echo "has_reports=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ needs.build-and-test.result }}" != "success" ]; then
+            {
+              echo "Artifact consolidation is deferred until all matrix jobs succeed."
+              echo "Per-configuration staging artifacts are retained for selective job reruns."
               echo ""
             } >> "$REPORT"
             echo "has_test_results=false" >> "$GITHUB_OUTPUT"
@@ -557,7 +574,7 @@ jobs:
 
       - name: Delete staging artifacts
         id: finalize-artifacts
-        if: always()
+        if: always() && needs.build-and-test.result == 'success'
         uses: actions/github-script@v7
         env:
           PACKAGE_VERSION: ${{ needs.check-changes.outputs.package_version }}


### PR DESCRIPTION
Defer aggregation and cleanup after matrix failures so selective job reruns can reuse successful jobs' staging artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly build reporting by preventing incomplete or failed build results from being consolidated as valid test and evaluation artifacts.
  * Staging artifacts are now deleted only after successful build-and-test completion.
  * Summary outputs now clearly indicate when no results could be consolidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->