### PR TITLE
[infra] Stop blocking nightly builds on source check

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -180,7 +180,6 @@ jobs:
             UBUNTU_VERSION=${{ matrix.ubuntu }} \
             BASE_IMAGE="${{ matrix.base_image }}" \
             UBUNTU_PORTS_MIRROR="${{ matrix.ports_mirror }}" \
-            CUVSLAM_REQUIRE_CLEAN_SOURCE=1 \
             EXTRA_CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=${{ matrix.archs }} ${{ matrix.cmake_options }}" \
             ./scripts/build_cuvslam_in_docker.sh Release ./output
 


### PR DESCRIPTION
Allow builds to proceed when container-side Git checks cannot inspect the read-only checkout reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly build automation to streamline the C++ library build process.
  * Existing build steps and configuration remain unchanged.
  * No user-facing features or product behavior were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->