### PR TITLE
[infra] Normalize Git state for nightly Docker builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -115,11 +115,9 @@ jobs:
         with:
           lfs: false
 
-      - name: Pull LFS test data
-        run: git lfs pull --include="test_data/"
-
-      - name: Configure Git for read-only Docker mount
+      - name: Prepare Git checkout for Docker build
         run: |
+          git lfs pull --include="test_data/"
           # Some runner filesystems normalize executable bits, and the LFS clean filter needs writable storage.
           git config --local core.fileMode false
           git config --local lfs.storage /tmp/cuvslam-lfs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,6 +118,12 @@ jobs:
       - name: Pull LFS test data
         run: git lfs pull --include="test_data/"
 
+      - name: Configure Git for read-only Docker mount
+        run: |
+          # Some runner filesystems normalize executable bits, and the LFS clean filter needs writable storage.
+          git config --local core.fileMode false
+          git config --local lfs.storage /tmp/cuvslam-lfs
+
       - name: Resolve runner storage root
         if: matrix.eval && vars.RUNNER_STORAGE_ROOT != ''
         run: echo "RUNNER_STORAGE_ROOT=${{ vars.RUNNER_STORAGE_ROOT }}" >> "$GITHUB_ENV"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,10 +117,10 @@ jobs:
 
       - name: Prepare Git checkout for Docker build
         run: |
-          git lfs pull --include="test_data/"
           # Some runner filesystems normalize executable bits, and the LFS clean filter needs writable storage.
           git config --local core.fileMode false
           git config --local lfs.storage /tmp/cuvslam-lfs
+          git lfs pull --include="test_data/"
 
       - name: Resolve runner storage root
         if: matrix.eval && vars.RUNNER_STORAGE_ROOT != ''


### PR DESCRIPTION
Ignore runner-specific mode normalization and give Git LFS writable temporary storage when the checkout is mounted read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the nightly Docker build workflow for more consistent Git and Git LFS behavior.
  * Adjusted Git and Git LFS settings to use a writable temporary LFS location during automated builds, enhancing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->