### PR TITLE
[infra] Add CUDA version check for USE_CUNLS

### DIFF
--- a/cmake/ext/cunls.cmake
+++ b/cmake/ext/cunls.cmake
@@ -25,6 +25,11 @@ if(NOT USE_CUDA)
     message(FATAL_ERROR "USE_CUNLS requires USE_CUDA")
 endif()
 
+if(CUDAToolkit_VERSION VERSION_LESS "12.6")
+    message(FATAL_ERROR "USE_CUNLS requires CUDA >= 12.6 (found ${CUDAToolkit_VERSION}). "
+                        "Either install CUDA 12.6+ or set -DUSE_CUNLS=OFF.")
+endif()
+
 set(CUNLS_VERSION "Release_07_13_2026")
 
 # Keep cuNLS's own tests and Python bindings out of this build.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a configuration check requiring CUDA Toolkit 12.6 or newer when building cuNLS.
  * Builds now fail early with a clear error when an unsupported CUDA version is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->