### PR TITLE
[refactor] Split AsyncSlam's background-thread logic into async_slam_worker.cpp

### DIFF
--- a/libs/slam/CMakeLists.txt
+++ b/libs/slam/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
     localizer/localizer.cpp
     async_slam/async_slam.cpp
     async_slam/async_slam_localize.cpp
+    async_slam/async_slam_worker.cpp
     async_slam/tail.cpp
     common/slam_common.cpp
     map/map.cpp

--- a/libs/slam/async_slam/async_slam.cpp
+++ b/libs/slam/async_slam/async_slam.cpp
@@ -21,9 +21,9 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "common/coordinate_system.h"
-#include "common/log_types.h"
 #include "common/rerun.h"
 #include "common/thread_safe_queue.h"
 #include "common/unaligned_types.h"
@@ -34,7 +34,6 @@
 #include "slam/map/database/lmdb_slam_database.h"
 #include "slam/slam/loop_closure_solver/iloop_closure_solver.h"
 #include "slam/slam/slam.h"
-#include "slam/view/map_to_view.h"
 #include "slam/view/view_landmarks.h"
 #include "sof/image_manager.h"
 #include "visualizer/visualizer.hpp"
@@ -70,20 +69,19 @@ namespace cuvslam::slam {
 AsyncSlam::AsyncSlam(const camera::Rig& rig, const std::vector<CameraId>& cameras, const AsyncSlamOptions& options)
     : rig_(rig),
       cameras_(cameras),
+      options_(options),
       slam_(std::make_unique<LocalizerAndMapper>(rig, FeatureDescriptorType::kShiTomasi6, options.use_gpu)),
-      tail_(options.retention_time_ms * 1'000'000ULL) {
+      tail_(options.retention_time_ms * 1'000'000ULL),
+      loop_closure_solver_(
+          CreateLoopClosureSolver(options.loop_closure_solver_type, RansacType::kPnP, !options.reproduce_mode, rig_)),
+      throttling_time_ns_(options.throttling_time_ms * 1'000'000) {
   reproduce_mode_ = options.reproduce_mode;
 
   // no second thread here - safe access to all data
-  options_ = options;
   slam_->SetReproduceMode(reproduce_mode_);
   slam_->SetLandmarksSpatialIndex(options.spatial_index_options);
-  const bool randomized = !reproduce_mode_;
-  loop_closure_solver_.reset(
-      CreateLoopClosureSolver(options.loop_closure_solver_type, RansacType::kPnP, randomized, rig_));
   slam_->SetPoseGraphOptimizerOptions(options.pgo_options);
   slam_->SetActiveCameras(cameras_);
-  throttling_time_ns_ = options.throttling_time_ms * 1'000'000;
 
   if (options.max_pose_graph_nodes) {
     slam_->SetKeyframesLimit(options.max_pose_graph_nodes);
@@ -102,7 +100,7 @@ AsyncSlam::AsyncSlam(const camera::Rig& rig, const std::vector<CameraId>& camera
 
   if (!reproduce_mode_) {
     SlamStdout("Starting background thread");
-    thread_ = std::thread{&AsyncSlam::Run, this};
+    thread_ = std::thread{&AsyncSlam::Run_worker, this};
   } else {
     SlamStdout("Do not start background thread because reproduce_mode is set.");
   }
@@ -112,8 +110,9 @@ AsyncSlam::~AsyncSlam() {
   SlamStdout("Destroyed AsyncSlam instance. ");
 }
 
-void AsyncSlam::TrackResult(FrameId frameId, int64_t timestamp_ns, const odom::IVisualOdometry::VOFrameStat& stat,
-                            const sof::Images& images, const Isometry3T& delta) {
+void AsyncSlam::TrackResult(const FrameId frameId, const int64_t timestamp_ns,
+                            const odom::IVisualOdometry::VOFrameStat& stat, const sof::Images& images,
+                            const Isometry3T& delta) {
   TRACE_EVENT ev = profiler_domain_.trace_event("AsyncSlam::TrackResult()", profiler_color_);
 
   assert(track_data_.from_keyframe.matrix().allFinite());
@@ -128,7 +127,7 @@ void AsyncSlam::TrackResult(FrameId frameId, int64_t timestamp_ns, const odom::I
     }
   }
 
-  bool is_keyframe = stat.keyframe;
+  const bool is_keyframe = stat.keyframe;
 
   // first frame
   if (is_first_frame_) {
@@ -158,11 +157,7 @@ void AsyncSlam::TrackResult(FrameId frameId, int64_t timestamp_ns, const odom::I
       vo_keyframe->frame_data.tracks2d_norm.reserve(stat.tracks2d.size());
 
       std::unordered_set<TrackId> added_tracks;
-      for (const auto& x : stat.tracks2d) {
-        const Vector2T& uv = x.uv;
-        Vector2T uv_norm;
-
-        const TrackId& track_id = x.track_id;
+      for (const auto& [cam_id, track_id, uv] : stat.tracks2d) {
         if (stat.tracks3d.find(track_id) == stat.tracks3d.end()) {
           continue;  // remove landmarks without 3d
         }
@@ -171,17 +166,18 @@ void AsyncSlam::TrackResult(FrameId frameId, int64_t timestamp_ns, const odom::I
           continue;  // remove landmarks outside the max distance
         }
 
-        if (x.cam_id >= images.size() || images[x.cam_id] == nullptr) {
+        if (cam_id >= images.size() || images[cam_id] == nullptr) {
           continue;
         }
-        if (x.cam_id >= rig_.num_cameras) {
+        if (cam_id >= rig_.num_cameras) {
           SlamStdout("Found track with invalid camera id");
           continue;  // skip invalid camera ID
         }
-        const auto& intrinsics = rig_.intrinsics[x.cam_id];
+        const auto& intrinsics = rig_.intrinsics[cam_id];
+        Vector2T uv_norm;
         intrinsics->normalizePoint(uv, uv_norm);
-        vo_keyframe->frame_data.tracks2d_norm.emplace_back(VOFrameData::Track2DXY{x.cam_id, x.track_id, uv_norm});
-        added_tracks.insert(x.track_id);
+        vo_keyframe->frame_data.tracks2d_norm.emplace_back(VOFrameData::Track2DXY{cam_id, track_id, uv_norm});
+        added_tracks.insert(track_id);
       }
       // xyz to camera space
       for (const auto& [track_id, xyz_rel] : stat.tracks3d) {
@@ -227,7 +223,7 @@ Isometry3T AsyncSlam::GetSlamPose() const {
 
 void AsyncSlam::ProcessInputSynchronously() {
   if (reproduce_mode_) {
-    ProcessInput();
+    ProcessInput_worker();
   }
 }
 
@@ -237,14 +233,14 @@ void AsyncSlam::Stop() {
   reproduce_mode_ = true;
 }
 
-bool AsyncSlam::GetPoseForFrame(FrameId frameId, Isometry3T& pose) const {
+bool AsyncSlam::GetPoseForFrame(const FrameId frameId, Isometry3T& pose) const {
   pose.setIdentity();
 
   if (!options_.pose_for_frame_required) {
     return false;
   }
 
-  auto it = trajectory_.find(frameId);
+  const auto it = trajectory_.find(frameId);
   if (it == trajectory_.end()) {
     SlamStderr("Pose not found for frame %zd.\n", static_cast<uint64_t>(frameId));
     return false;
@@ -255,8 +251,7 @@ bool AsyncSlam::GetPoseForFrame(FrameId frameId, Isometry3T& pose) const {
   Isometry3T m;
   std::lock_guard slam_guard(slam_mutex_);
   if (slam_->CalcFramePose(track_data.end_frame_id, m)) {
-    m = m * track_data.from_keyframe;
-    pose = m;
+    pose = m * track_data.from_keyframe;
     return true;
   }
 
@@ -269,16 +264,14 @@ bool AsyncSlam::GetPosesForAllFrames(std::map<uint64_t, storage::Isometry3<float
   }
 
   std::lock_guard slam_guard(slam_mutex_);
-  for (auto it : trajectory_) {
-    auto& track_data = it.second;
-    uint64_t timestamp_ns = it.second.timestamp_ns;
+  for (const auto& [frame_id, track_data] : trajectory_) {
+    (void)frame_id;
     assert(track_data.from_keyframe.matrix().allFinite());
 
     Isometry3T m;
     if (slam_->CalcFramePose(track_data.end_frame_id, m)) {
-      m = m * track_data.from_keyframe;
-      Isometry3T pose = m;
-      frames[timestamp_ns] = pose;
+      const Isometry3T pose = m * track_data.from_keyframe;
+      frames[track_data.timestamp_ns] = pose;
     }
   }
   return true;
@@ -309,238 +302,23 @@ void AsyncSlam::CopyToDatabase(const std::string& path, const std::function<void
   }
 }
 
-bool AsyncSlam::CopyToDatabase_internal(const std::string& path) {
-  const bool status = slam_->AttachToNewDatabaseSaveMapAndDetach(path);
-  if (copy_to_database_callback_) {
-    copy_to_database_callback_(status);
-  }
-  copy_to_database_callback_ = nullptr;
-  return status;
+void AsyncSlam::CopyToDatabaseCmd::Execute(AsyncSlam& async_slam, FrameId, const Isometry3T&) {
+  async_slam.CopyToDatabase_worker(path_);
 }
 
 // Set landmarks view
-void AsyncSlam::SetLandmarksView(std::shared_ptr<ViewManager<ViewLandmarks>> view) { this->landmarks_view_ = view; }
-
-// Set loop closure view
-void AsyncSlam::SetLoopClosureView(std::shared_ptr<ViewManager<ViewLandmarks>> view) { this->loop_close_view_ = view; }
-
-// Set pose graph view
-void AsyncSlam::SetPoseGraphView(std::shared_ptr<ViewManager<ViewPoseGraph>> view) { this->pose_graph_view_ = view; }
-
-void AsyncSlam::Run() {
-#ifdef USE_CUDA
-  if (options_.use_gpu) {
-    cudaSetDevice(0);
-  }
-#endif
-  for (;;) {
-    // wait for news in input_queue
-    if (!input_queue_.Wait()) {
-      // aborted
-      return;
-    }
-    ProcessInput();
-  }
+void AsyncSlam::SetLandmarksView(std::shared_ptr<ViewManager<ViewLandmarks>> view) {
+  this->landmarks_view_ = std::move(view);
 }
 
-void AsyncSlam::ProcessInput() {
-  FrameId end_frame_id = InvalidFrameId;
-  Isometry3T vo_pose_at_that_frame = Isometry3T::Identity();
+// Set loop closure view
+void AsyncSlam::SetLoopClosureView(std::shared_ptr<ViewManager<ViewLandmarks>> view) {
+  this->loop_close_view_ = std::move(view);
+}
 
-  Isometry3T world_from_rig_guess;
-  FrameId frame_id = InvalidFrameId;
-  uint64_t timestamp_ns = 0;
-  bool has_input = false;
-
-  Images current_images;
-
-  for (;;) {
-    TRACE_EVENT ev = profiler_domain_.trace_event("process vo data", profiler_color_);
-
-    // extract all from input_queue
-    std::shared_ptr<VOKeyframeInfo> vo_kf;
-    {
-      TRACE_EVENT ev_input = profiler_domain_.trace_event("input", profiler_color_);
-      if (!input_queue_.TryPop(vo_kf)) {
-        break;  // input_queue_ is empty
-      }
-    }
-
-    const auto& frame_data = vo_kf->frame_data;
-    RERUN(visualizer::RerunVisualizer::getInstance().setupTimeline, frame_data.frame_id, frame_data.timestamp_ns);
-
-    // execute command from input_queue_
-    if (vo_kf->command) {
-      std::shared_ptr<ICommand>& cmd = vo_kf->command;
-      cmd->Execute(*this, end_frame_id, vo_pose_at_that_frame);
-      continue;
-    }
-
-    {
-      std::lock_guard image_guard(processing_images_mutex_);
-      current_images = processing_images_;
-    }
-    const auto current_image =
-        std::find_if(current_images.begin(), current_images.end(), [](const auto& image) { return image != nullptr; });
-    const bool is_valid_image =
-        current_image != current_images.end() && ((*current_image)->get_image_meta().frame_id == frame_data.frame_id);
-    Isometry3T pose_estimate_slam;
-    {
-      const VOTrackData& track_data = vo_kf->track_data;
-
-      Isometry3T last_keyframe_pose;
-      int64_t last_keyframe_ts;
-      if (slam_->GetLastKeyframePoseAndTimestamp(last_keyframe_pose, last_keyframe_ts) && last_keyframe_ts > 0 &&
-          track_data.timestamp_ns < static_cast<uint64_t>(last_keyframe_ts)) {
-        continue;  // no need to add keyframe in past if slam in a future
-      }
-      std::lock_guard slam_guard(slam_mutex_);
-      slam_->AddKeyframe(track_data.from_keyframe, frame_data, is_valid_image ? current_images : Images());
-      pose_estimate_slam = slam_->GetCurrentPose();
-    }
-    SlamStdout("'");
-
-    {
-      TRACE_EVENT ev_cd = profiler_domain_.trace_event("copy data", profiler_color_);
-
-      frame_id = frame_data.frame_id;
-      timestamp_ns = frame_data.timestamp_ns;
-      end_frame_id = vo_kf->track_data.end_frame_id;
-      vo_pose_at_that_frame = vo_kf->vo_pose_at_this_frame;
-      world_from_rig_guess = pose_estimate_slam;
-    }
-
-    vo_kf.reset();
-    has_input = true;
-  }
-  {
-    std::lock_guard slam_guard(slam_mutex_);
-    slam_->ReduceKeyframes();
-  }
-  if (!has_input) {
-    return;
-  }
-  {
-    std::lock_guard image_guard(processing_images_mutex_);
-    current_images = processing_images_;
-  }
-  const auto current_image =
-      std::find_if(current_images.begin(), current_images.end(), [](const auto& image) { return image != nullptr; });
-  bool is_valid_image =
-      current_image != current_images.end() && ((*current_image)->get_image_meta().frame_id == frame_id);
-
-  if (is_valid_image) {
-    // init last_step_telemetry_
-    AsyncSlamLCTelemetry last_step_telemetry;
-    last_step_telemetry.timestamp_ns = timestamp_ns;
-
-    TRACE_EVENT ev = profiler_domain_.trace_event("LC & optimization", profiler_color_);
-
-    bool skip_loop_closure = false;
-    if (!last_loop_closures_stamped_.empty()) {
-      // no need for LC if previous LC was recent
-      if ((timestamp_ns - last_loop_closures_stamped_.back().timestamp_ns) < throttling_time_ns_) {
-        skip_loop_closure = true;  // loop closure not needed
-      }
-    }
-
-    //--- Loop Closure detection ---
-    if (loop_closure_solver_ != nullptr && !skip_loop_closure) {
-      LocalizerAndMapper::LoopClosureStatus lc_status;
-      bool lc_found = false;
-      {
-        std::lock_guard slam_guard(slam_mutex_);
-        slam_->DetectLoopClosure(*loop_closure_solver_, current_images, world_from_rig_guess, lc_status);
-        lc_found = lc_status.success;
-      }
-
-      // view loop closure
-      std::shared_ptr<ViewLandmarks> lc_view = loop_close_view_ ? loop_close_view_->acquire_earliest() : nullptr;
-      if (lc_view) {
-        std::lock_guard slam_guard(slam_mutex_);
-        PublishLoopClosureToView(slam_->GetMap(), lc_status.landmarks, *lc_view);
-        lc_view->timestamp_ns = timestamp_ns;
-        lc_view.reset();
-      }
-
-      // Update Landmark Statistic in spatial index
-      {
-        std::lock_guard slam_guard(slam_mutex_);
-        slam_->UpdateLandmarkProbeStatistics(lc_status.discarded_landmarks);
-      }
-      // Add LC edge and Add Landmark Relation to spatial index and pose graph
-      if (lc_found) {
-        std::lock_guard slam_guard(slam_mutex_);
-        if (slam_->ApplyLoopClosureResult(lc_status.result_pose, lc_status.result_pose_covariance,
-                                          lc_status.landmarks)) {
-          const LoopClosureStamped lc_pose_stamped = {frame_id, timestamp_ns, lc_status.result_pose};
-          last_loop_closures_stamped_.push_back(lc_pose_stamped);
-          while (last_loop_closures_stamped_.size() > max_num_last_lcs_) {
-            last_loop_closures_stamped_.pop_front();
-          }
-        } else {
-          SlamStdout("Can't apply loop closure result");
-        }
-      }
-
-      last_step_telemetry.lc_status = lc_found;
-      last_step_telemetry.lc_selected_landmarks_count = lc_status.selected_landmarks_count;
-      last_step_telemetry.lc_tracked_landmarks_count = lc_status.tracked_landmarks_count;
-      last_step_telemetry.lc_pnp_landmarks_count = lc_status.pnp_landmarks_count;
-      last_step_telemetry.lc_good_landmarks_count = lc_status.good_landmarks_count;
-      if (lc_found) {
-        SlamStdout("S");  // Successful LC
-      }
-      // Slam Pose Graph Optimization
-      bool optimization_happens = false;
-      if (lc_found || options_.planar_constraints) {
-        // TODO: ? optimize_options.keyframes_in_sight = loop_closure_status.keyframes_in_sight;
-        std::lock_guard slam_guard(slam_mutex_);
-
-        optimization_happens = slam_->OptimizePoseGraph(options_.planar_constraints);
-      }
-      if (optimization_happens) {
-        const Isometry3T pose_estimate_slam = slam_->GetCurrentPose();
-        TRACE_EVENT ev1 = profiler_domain_.trace_event("post optimization", profiler_color_);
-        log::Value<LogFrames>("pose_slam", pose_estimate_slam);
-        last_step_telemetry.pgo_status = true;
-
-        int64_t last_keyframe_ts;
-        Isometry3T last_keyframe_pose;
-        if (slam_->GetLastKeyframePoseAndTimestamp(last_keyframe_pose, last_keyframe_ts)) {
-          if (!tail_.UpdatePoseBySLAM(last_keyframe_ts, last_keyframe_pose)) {
-            TraceWarning(
-                "Failed to update SLAM tail after pose graph optimization: keyframe timestamp is outside retention.");
-          }
-        }
-
-        SlamStdout(":");
-      }
-      telemetry_queue_.Push(std::make_shared<AsyncSlamLCTelemetry>(last_step_telemetry));
-    }
-  }
-
-  // view landmarks
-  std::shared_ptr<ViewLandmarks> landmarks_view = landmarks_view_ ? landmarks_view_->acquire_earliest() : nullptr;
-  if (landmarks_view) {
-    std::lock_guard slam_guard(slam_mutex_);
-    landmarks_view->landmarks.clear();
-    PublishAllLandmarksToView(slam_->GetMap(), timestamp_ns, *landmarks_view);
-    landmarks_view.reset();
-  }
-
-  // view pose graph
-  std::shared_ptr<ViewPoseGraph> pose_graph_view = pose_graph_view_ ? pose_graph_view_->acquire_earliest() : nullptr;
-  if (pose_graph_view) {
-    std::lock_guard slam_guard(slam_mutex_);
-    PublishPoseGraphToView(slam_->GetMap(), timestamp_ns, *pose_graph_view);
-    pose_graph_view.reset();
-  }
-
-  if (input_queue_.IsEmpty()) {
-    std::lock_guard slam_guard(slam_mutex_);
-    slam_->FlushActiveDatabase();
-  }
+// Set pose graph view
+void AsyncSlam::SetPoseGraphView(std::shared_ptr<ViewManager<ViewPoseGraph>> view) {
+  this->pose_graph_view_ = std::move(view);
 }
 
 void AsyncSlam::Shutdown() {
@@ -582,17 +360,17 @@ std::string AsyncSlam::FrameInformationString(const sof::Images& images) {
 }
 
 // reset VOFrameData (if data was post to ProcessVOFrameData)
-void AsyncSlam::VO_ResetFrameData(FrameId frame_id, uint64_t timestamp_ns, VOTrackData& data) {
-  data.end_frame_id = frame_id;
-  data.timestamp_ns = timestamp_ns;
-  data.from_keyframe = Isometry3T::Identity();
+void AsyncSlam::VO_ResetFrameData(const FrameId frame_id, const uint64_t timestamp_ns, VOTrackData& track_data) {
+  track_data.end_frame_id = frame_id;
+  track_data.timestamp_ns = timestamp_ns;
+  track_data.from_keyframe = Isometry3T::Identity();
 }
 
-void AsyncSlam::VO_IncrementFrameData(FrameId frame_id, uint64_t timestamp_ns, const Isometry3T& pose_estimate_rel,
-                                      VOTrackData& data) {
-  data.end_frame_id = frame_id;
-  data.timestamp_ns = timestamp_ns;
-  data.from_keyframe = data.from_keyframe * pose_estimate_rel;
+void AsyncSlam::VO_IncrementFrameData(const FrameId frame_id, const uint64_t timestamp_ns,
+                                      const Isometry3T& pose_estimate_rel, VOTrackData& track_data) {
+  track_data.end_frame_id = frame_id;
+  track_data.timestamp_ns = timestamp_ns;
+  track_data.from_keyframe = track_data.from_keyframe * pose_estimate_rel;
 }
 
 }  // namespace cuvslam::slam

--- a/libs/slam/async_slam/async_slam.cpp
+++ b/libs/slam/async_slam/async_slam.cpp
@@ -157,6 +157,7 @@ void AsyncSlam::TrackResult(const FrameId frameId, const int64_t timestamp_ns,
       vo_keyframe->frame_data.tracks2d_norm.reserve(stat.tracks2d.size());
 
       std::unordered_set<TrackId> added_tracks;
+      int invalid_cam_id_count = 0;
       for (const auto& [cam_id, track_id, uv] : stat.tracks2d) {
         if (stat.tracks3d.find(track_id) == stat.tracks3d.end()) {
           continue;  // remove landmarks without 3d
@@ -170,7 +171,7 @@ void AsyncSlam::TrackResult(const FrameId frameId, const int64_t timestamp_ns,
           continue;
         }
         if (cam_id >= rig_.num_cameras) {
-          SlamStdout("Found track with invalid camera id");
+          ++invalid_cam_id_count;
           continue;  // skip invalid camera ID
         }
         const auto& intrinsics = rig_.intrinsics[cam_id];
@@ -178,6 +179,9 @@ void AsyncSlam::TrackResult(const FrameId frameId, const int64_t timestamp_ns,
         intrinsics->normalizePoint(uv, uv_norm);
         vo_keyframe->frame_data.tracks2d_norm.emplace_back(VOFrameData::Track2DXY{cam_id, track_id, uv_norm});
         added_tracks.insert(track_id);
+      }
+      if (invalid_cam_id_count > 0) {
+        SlamStdout("Skipped %d track(s) with invalid camera id", invalid_cam_id_count);
       }
       // xyz to camera space
       for (const auto& [track_id, xyz_rel] : stat.tracks3d) {

--- a/libs/slam/async_slam/async_slam.cpp
+++ b/libs/slam/async_slam/async_slam.cpp
@@ -175,6 +175,10 @@ void AsyncSlam::TrackResult(const FrameId frameId, const int64_t timestamp_ns,
           continue;  // skip invalid camera ID
         }
         const auto& intrinsics = rig_.intrinsics[cam_id];
+        if (intrinsics == nullptr) {
+          SlamStderr("Intrinsics for camera %zu should not be null", static_cast<size_t>(cam_id));
+          continue;
+        }
         Vector2T uv_norm;
         intrinsics->normalizePoint(uv, uv_norm);
         vo_keyframe->frame_data.tracks2d_norm.emplace_back(VOFrameData::Track2DXY{cam_id, track_id, uv_norm});

--- a/libs/slam/async_slam/async_slam.h
+++ b/libs/slam/async_slam/async_slam.h
@@ -157,11 +157,13 @@ private:
     void Execute(AsyncSlam& async_slam, FrameId, const Isometry3T&) override;
   };
 
-  // --- Accessed only from the caller's thread (e.g. TrackResult(), GetPoseForFrame() callers) ---
-  bool reproduce_mode_ = false;
+  // --- Immutable after construction; read by both the caller's thread and the background worker thread ---
   const camera::Rig rig_;
   const std::vector<CameraId> cameras_;
   const AsyncSlamOptions options_;
+
+  // --- Accessed only from the caller's thread (e.g. TrackResult(), GetPoseForFrame() callers) ---
+  bool reproduce_mode_ = false;
   std::thread thread_;
   bool is_first_frame_ = true;
   VOTrackData track_data_;

--- a/libs/slam/async_slam/async_slam.h
+++ b/libs/slam/async_slam/async_slam.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "common/camera_id.h"
 #include "common/thread_safe_queue.h"
@@ -64,8 +65,8 @@ struct AsyncSlamLCTelemetry {
 };
 
 struct LoopClosureStamped {
-  FrameId frame_id;
-  uint64_t timestamp_ns;
+  FrameId frame_id = InvalidFrameId;
+  uint64_t timestamp_ns = 0;
   Isometry3T pose;
 };
 
@@ -106,29 +107,10 @@ public:
 
 private:
   struct VOTrackData {
-    FrameId end_frame_id;
-    uint64_t timestamp_ns;
+    FrameId end_frame_id = InvalidFrameId;
+    uint64_t timestamp_ns = 0;
     Isometry3T from_keyframe = Isometry3T::Identity();
   };
-
-  bool reproduce_mode_ = false;
-  camera::Rig rig_;
-  const std::vector<CameraId> cameras_;
-  AsyncSlamOptions options_;
-  mutable std::mutex slam_mutex_;
-  std::unique_ptr<LocalizerAndMapper> slam_;                 // should be protected by slam_mutex_
-  Tail tail_;                                                // thread-safe
-  std::unique_ptr<ILoopClosureSolver> loop_closure_solver_;  // should be accessed from slam thread only
-  std::map<FrameId, VOTrackData> trajectory_;
-
-  std::thread thread_;
-
-  bool is_first_frame_ = true;
-  VOTrackData track_data_;
-
-  // profiler
-  profiler::SLAMProfiler::DomainHelper profiler_domain_ = profiler::SLAMProfiler::DomainHelper("SLAM");
-  uint32_t profiler_color_ = 0x00FF00;
 
   class ICommand {
   public:
@@ -143,10 +125,6 @@ private:
     Isometry3T vo_pose_at_this_frame;
     std::shared_ptr<ICommand> command;
   };
-
-  //
-  std::mutex processing_images_mutex_;
-  Images processing_images_;  // should be protected by processing_images_mutex_
 
   class LocalizeInMapCmd : public ICommand {
   public:
@@ -170,38 +148,70 @@ private:
   class CopyToDatabaseCmd : public ICommand {
   public:
     std::string path_;
-    explicit CopyToDatabaseCmd(const std::string& path) : path_(path) {}
+    explicit CopyToDatabaseCmd(std::string path) : path_(std::move(path)) {}
     ~CopyToDatabaseCmd() override = default;
 
-    void Execute(AsyncSlam& async_slam, FrameId, const Isometry3T&) override {
-      async_slam.CopyToDatabase_internal(path_);
-    }
+    void Execute(AsyncSlam& async_slam, FrameId, const Isometry3T&) override;
   };
 
+  // --- Accessed only from the caller's thread (e.g. TrackResult(), GetPoseForFrame() callers) ---
+  bool reproduce_mode_ = false;
+  const camera::Rig rig_;
+  const std::vector<CameraId> cameras_;
+  const AsyncSlamOptions options_;
+  std::thread thread_;
+  bool is_first_frame_ = true;
+  VOTrackData track_data_;
+  std::map<FrameId, VOTrackData> trajectory_;
+  AsyncSlamLCTelemetry last_telemetry_;  // cache of the telemetry last popped from telemetry_queue_
+
+  // --- Shared between the caller's thread and the background worker thread (see async_slam_worker.cpp) ---
+  mutable std::mutex slam_mutex_;
+  std::unique_ptr<LocalizerAndMapper> slam_;  // protected by slam_mutex_
+  Tail tail_;                                 // thread-safe
+  std::mutex processing_images_mutex_;
+  Images processing_images_;  // protected by processing_images_mutex_
   ThreadSafeQueue<std::shared_ptr<VOKeyframeInfo>> input_queue_;
   ThreadSafeQueue<std::shared_ptr<AsyncSlamLCTelemetry>> telemetry_queue_;
-  // telemetry of last ProcessInput()
-  AsyncSlamLCTelemetry last_telemetry_;
+  std::list<LoopClosureStamped> last_loop_closures_stamped_;     // TODO: check for raise condition
+  std::shared_ptr<ViewManager<ViewLandmarks>> landmarks_view_;   // TODO: check for raise condition
+  std::shared_ptr<ViewManager<ViewLandmarks>> loop_close_view_;  // TODO: check for raise condition
+  std::shared_ptr<ViewManager<ViewPoseGraph>> pose_graph_view_;  // TODO: check for raise condition
+  std::function<void(bool)> copy_to_database_callback_;          // TODO: check for raise condition
+  const profiler::SLAMProfiler::DomainHelper profiler_domain_ = profiler::SLAMProfiler::DomainHelper("SLAM");
+  const uint32_t profiler_color_ = 0x00FF00;
 
-  // set max size for list of the last loop closure poses with timestamps and frame_ids
-  uint32_t max_num_last_lcs_ = 10;
-  // set time interval allowed between successive loop closures;
-  uint64_t throttling_time_ns_ = 0;
-  std::list<LoopClosureStamped> last_loop_closures_stamped_;
+  // --- Accessed only from the background worker thread ---
+  const std::unique_ptr<ILoopClosureSolver> loop_closure_solver_;
+  // max size for the list of last loop closure poses with timestamps/frame_ids
+  static constexpr uint32_t max_num_last_lcs_ = 10;
+  const uint64_t throttling_time_ns_;  // min time interval allowed between successive loop closures
 
-  std::shared_ptr<ViewManager<ViewLandmarks>> landmarks_view_;
-  std::shared_ptr<ViewManager<ViewLandmarks>> loop_close_view_;
-  std::shared_ptr<ViewManager<ViewPoseGraph>> pose_graph_view_;
-
-  std::function<void(bool)> copy_to_database_callback_;
-
-  void Run();
   void Shutdown();
 
-  void ProcessInput();
+  // Background thread entry point (launched via thread_ = std::thread{&AsyncSlam::Run_worker, this}).
+  void Run_worker();
+
+  void ProcessInput_worker();
+
+  // Pops all pending items from input_queue_, executing commands and adding VO keyframes to slam_.
+  // Writes the last processed keyframe's frame_id/timestamp_ns/world_from_rig_guess (used by the caller
+  // to run loop closure / pose graph optimization once on the freshest state of the batch).
+  // Returns true if at least one VO keyframe was added.
+  bool AddKeyframesAndRunCommands_worker(FrameId& frame_id, uint64_t& timestamp_ns, Isometry3T& world_from_rig_guess);
+
+  // Returns the current processing_images_ if they match frame_id, false otherwise.
+  bool GetLatestProcessingImages_worker(FrameId frame_id, Images& current_images);
+
+  // Loop closure detection + pose graph optimization for the given batch's latest state.
+  void RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t timestamp_ns,
+                                            const Isometry3T& world_from_rig_guess, const Images& current_images);
+
+  // Publishes landmarks and pose graph to their respective views, if attached.
+  void PublishViews_worker(uint64_t timestamp_ns);
 
   // Copy to database
-  bool CopyToDatabase_internal(const std::string& path);
+  bool CopyToDatabase_worker(const std::string& path);
 
   // reset VOFrameData (if data was post to ProcessVOFrameData)
   static void VO_ResetFrameData(FrameId frame_id, uint64_t timestamp_ns, VOTrackData& track_data);

--- a/libs/slam/async_slam/async_slam.h
+++ b/libs/slam/async_slam/async_slam.h
@@ -209,8 +209,11 @@ private:
   bool GetLatestProcessingImages_worker(FrameId frame_id, Images& current_images);
 
   // Loop closure detection + pose graph optimization for the given batch's latest state.
-  void RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t timestamp_ns,
-                                            const Isometry3T& world_from_rig_guess, const Images& current_images);
+  void DetectLoopClosure_worker(FrameId frame_id, uint64_t timestamp_ns, const Isometry3T& world_from_rig_guess,
+                                const Images& current_images);
+
+  // Runs pose graph optimization if lc_found or planar_constraints. Returns true if optimization ran.
+  bool OptimizePoseGraph_worker(bool lc_found);
 
   // Publishes landmarks and pose graph to their respective views, if attached.
   void PublishViews_worker(uint64_t timestamp_ns);

--- a/libs/slam/async_slam/async_slam_worker.cpp
+++ b/libs/slam/async_slam/async_slam_worker.cpp
@@ -86,11 +86,11 @@ bool AsyncSlam::AddKeyframesAndRunCommands_worker(FrameId& frame_id, uint64_t& t
 
       Isometry3T last_keyframe_pose;
       int64_t last_keyframe_ts;
+      std::lock_guard slam_guard(slam_mutex_);
       if (slam_->GetLastKeyframePoseAndTimestamp(last_keyframe_pose, last_keyframe_ts) && last_keyframe_ts > 0 &&
           track_data.timestamp_ns < static_cast<uint64_t>(last_keyframe_ts)) {
         continue;  // no need to add keyframe in past if slam in a future
       }
-      std::lock_guard slam_guard(slam_mutex_);
       slam_->AddKeyframe(track_data.from_keyframe, frame_data, is_valid_image ? current_images : Images());
       pose_estimate_slam = slam_->GetCurrentPose();
     }
@@ -197,6 +197,7 @@ void AsyncSlam::RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t 
     optimization_happens = slam_->OptimizePoseGraph(options_.planar_constraints);
   }
   if (optimization_happens) {
+    std::lock_guard slam_guard(slam_mutex_);
     const Isometry3T pose_estimate_slam = slam_->GetCurrentPose();
     TRACE_EVENT ev1 = profiler_domain_.trace_event("post optimization", profiler_color_);
     log::Value<LogFrames>("pose_slam", pose_estimate_slam);
@@ -264,7 +265,11 @@ void AsyncSlam::ProcessInput_worker() {
 }
 
 bool AsyncSlam::CopyToDatabase_worker(const std::string& path) {
-  const bool status = slam_->AttachToNewDatabaseSaveMapAndDetach(path);
+  bool status;
+  {
+    std::lock_guard slam_guard(slam_mutex_);
+    status = slam_->AttachToNewDatabaseSaveMapAndDetach(path);
+  }
   if (copy_to_database_callback_) {
     copy_to_database_callback_(status);
   }

--- a/libs/slam/async_slam/async_slam_worker.cpp
+++ b/libs/slam/async_slam/async_slam_worker.cpp
@@ -122,9 +122,8 @@ bool AsyncSlam::GetLatestProcessingImages_worker(FrameId frame_id, Images& curre
   return current_image != current_images.end() && ((*current_image)->get_image_meta().frame_id == frame_id);
 }
 
-void AsyncSlam::RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t timestamp_ns,
-                                                     const Isometry3T& world_from_rig_guess,
-                                                     const Images& current_images) {
+void AsyncSlam::DetectLoopClosure_worker(FrameId frame_id, uint64_t timestamp_ns,
+                                         const Isometry3T& world_from_rig_guess, const Images& current_images) {
   // init last_step_telemetry_
   AsyncSlamLCTelemetry last_step_telemetry;
   last_step_telemetry.timestamp_ns = timestamp_ns;
@@ -188,20 +187,25 @@ void AsyncSlam::RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t 
   if (lc_found) {
     SlamStdout("S");  // Successful LC
   }
-  // Slam Pose Graph Optimization
+  last_step_telemetry.pgo_status = OptimizePoseGraph_worker(lc_found);
+  telemetry_queue_.Push(std::make_shared<AsyncSlamLCTelemetry>(last_step_telemetry));
+}
+
+bool AsyncSlam::OptimizePoseGraph_worker(bool lc_found) {
   bool optimization_happens = false;
   if (lc_found || options_.planar_constraints) {
     // TODO: ? optimize_options.keyframes_in_sight = loop_closure_status.keyframes_in_sight;
     std::lock_guard slam_guard(slam_mutex_);
-
     optimization_happens = slam_->OptimizePoseGraph(options_.planar_constraints);
   }
-  if (optimization_happens) {
+  if (!optimization_happens) {
+    return false;
+  }
+  {
     std::lock_guard slam_guard(slam_mutex_);
     const Isometry3T pose_estimate_slam = slam_->GetCurrentPose();
     TRACE_EVENT ev1 = profiler_domain_.trace_event("post optimization", profiler_color_);
     log::Value<LogFrames>("pose_slam", pose_estimate_slam);
-    last_step_telemetry.pgo_status = true;
 
     int64_t last_keyframe_ts;
     Isometry3T last_keyframe_pose;
@@ -211,10 +215,9 @@ void AsyncSlam::RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t 
             "Failed to update SLAM tail after pose graph optimization: keyframe timestamp is outside retention.");
       }
     }
-
-    SlamStdout(":");
   }
-  telemetry_queue_.Push(std::make_shared<AsyncSlamLCTelemetry>(last_step_telemetry));
+  SlamStdout(":");
+  return true;
 }
 
 void AsyncSlam::PublishViews_worker(uint64_t timestamp_ns) {
@@ -253,7 +256,7 @@ void AsyncSlam::ProcessInput_worker() {
   Images current_images;
   const bool is_valid_image = GetLatestProcessingImages_worker(frame_id, current_images);
   if (is_valid_image) {
-    RunLoopClosureAndOptimization_worker(frame_id, timestamp_ns, world_from_rig_guess, current_images);
+    DetectLoopClosure_worker(frame_id, timestamp_ns, world_from_rig_guess, current_images);
   }
 
   PublishViews_worker(timestamp_ns);

--- a/libs/slam/async_slam/async_slam_worker.cpp
+++ b/libs/slam/async_slam/async_slam_worker.cpp
@@ -132,8 +132,9 @@ void AsyncSlam::DetectLoopClosure_worker(FrameId frame_id, uint64_t timestamp_ns
 
   bool skip_loop_closure = false;
   if (!last_loop_closures_stamped_.empty()) {
-    // no need for LC if previous LC was recent
-    if ((timestamp_ns - last_loop_closures_stamped_.back().timestamp_ns) < throttling_time_ns_) {
+    // no need for LC if previous LC was recent; treat out-of-order timestamps as within the window
+    const uint64_t last_lc_ts = last_loop_closures_stamped_.back().timestamp_ns;
+    if (timestamp_ns < last_lc_ts || (timestamp_ns - last_lc_ts) < throttling_time_ns_) {
       skip_loop_closure = true;  // loop closure not needed
     }
   }

--- a/libs/slam/async_slam/async_slam_worker.cpp
+++ b/libs/slam/async_slam/async_slam_worker.cpp
@@ -1,0 +1,282 @@
+
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+ * the further development of AI and robotics technologies. Such software has been designed, tested,
+ * and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+ * solely with such hardware.
+ * Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+ * modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+ * outputs generated using the software or derivative works thereof. Any code contributions that you
+ * share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+ * in future releases without notice or attribution.
+ * By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+ * of the software or derivative works thereof, you agree to be bound by this License.
+ */
+
+#include "slam/async_slam/async_slam.h"
+
+#include <algorithm>
+
+#include "common/log_types.h"
+#include "common/rerun.h"
+#include "common/thread_safe_queue.h"
+#include "cuvslam/internal.h"
+#include "profiler/profiler.h"
+#include "slam/slam/slam.h"
+#include "slam/view/map_to_view.h"
+#include "slam/view/view_landmarks.h"
+#include "visualizer/visualizer.hpp"
+
+namespace cuvslam::slam {
+
+// Run_worker() is the background thread entry point. The other methods below also run on that thread
+// in async mode, or synchronously on the caller's thread via ProcessInputSynchronously() in reproduce_mode.
+
+void AsyncSlam::Run_worker() {
+#ifdef USE_CUDA
+  if (options_.use_gpu) {
+    cudaSetDevice(0);
+  }
+#endif
+  for (;;) {
+    // wait for news in input_queue
+    if (!input_queue_.Wait()) {
+      // aborted
+      return;
+    }
+    ProcessInput_worker();
+  }
+}
+
+bool AsyncSlam::AddKeyframesAndRunCommands_worker(FrameId& frame_id, uint64_t& timestamp_ns,
+                                                  Isometry3T& world_from_rig_guess) {
+  FrameId end_frame_id = InvalidFrameId;
+  Isometry3T vo_pose_at_that_frame = Isometry3T::Identity();
+  bool has_input = false;
+
+  for (;;) {
+    TRACE_EVENT ev = profiler_domain_.trace_event("process vo data", profiler_color_);
+
+    // extract all from input_queue
+    std::shared_ptr<VOKeyframeInfo> vo_kf;
+    {
+      TRACE_EVENT ev_input = profiler_domain_.trace_event("input", profiler_color_);
+      if (!input_queue_.TryPop(vo_kf)) {
+        break;  // input_queue_ is empty
+      }
+    }
+
+    const auto& frame_data = vo_kf->frame_data;
+    RERUN(visualizer::RerunVisualizer::getInstance().setupTimeline, frame_data.frame_id, frame_data.timestamp_ns);
+
+    // execute command from input_queue_
+    if (vo_kf->command) {
+      std::shared_ptr<ICommand>& cmd = vo_kf->command;
+      cmd->Execute(*this, end_frame_id, vo_pose_at_that_frame);
+      continue;
+    }
+
+    Images current_images;
+    {
+      std::lock_guard image_guard(processing_images_mutex_);
+      current_images = processing_images_;
+    }
+    const auto current_image =
+        std::find_if(current_images.begin(), current_images.end(), [](const auto& image) { return image != nullptr; });
+    const bool is_valid_image =
+        current_image != current_images.end() && ((*current_image)->get_image_meta().frame_id == frame_data.frame_id);
+    Isometry3T pose_estimate_slam;
+    {
+      const VOTrackData& track_data = vo_kf->track_data;
+
+      Isometry3T last_keyframe_pose;
+      int64_t last_keyframe_ts;
+      if (slam_->GetLastKeyframePoseAndTimestamp(last_keyframe_pose, last_keyframe_ts) && last_keyframe_ts > 0 &&
+          track_data.timestamp_ns < static_cast<uint64_t>(last_keyframe_ts)) {
+        continue;  // no need to add keyframe in past if slam in a future
+      }
+      std::lock_guard slam_guard(slam_mutex_);
+      slam_->AddKeyframe(track_data.from_keyframe, frame_data, is_valid_image ? current_images : Images());
+      pose_estimate_slam = slam_->GetCurrentPose();
+    }
+    SlamStdout("'");
+
+    {
+      TRACE_EVENT ev_cd = profiler_domain_.trace_event("copy data", profiler_color_);
+
+      frame_id = frame_data.frame_id;
+      timestamp_ns = frame_data.timestamp_ns;
+      end_frame_id = vo_kf->track_data.end_frame_id;
+      vo_pose_at_that_frame = vo_kf->vo_pose_at_this_frame;
+      world_from_rig_guess = pose_estimate_slam;
+    }
+
+    vo_kf.reset();
+    has_input = true;
+  }
+  return has_input;
+}
+
+bool AsyncSlam::GetLatestProcessingImages_worker(FrameId frame_id, Images& current_images) {
+  {
+    std::lock_guard image_guard(processing_images_mutex_);
+    current_images = processing_images_;
+  }
+  const auto current_image =
+      std::find_if(current_images.begin(), current_images.end(), [](const auto& image) { return image != nullptr; });
+  return current_image != current_images.end() && ((*current_image)->get_image_meta().frame_id == frame_id);
+}
+
+void AsyncSlam::RunLoopClosureAndOptimization_worker(FrameId frame_id, uint64_t timestamp_ns,
+                                                     const Isometry3T& world_from_rig_guess,
+                                                     const Images& current_images) {
+  // init last_step_telemetry_
+  AsyncSlamLCTelemetry last_step_telemetry;
+  last_step_telemetry.timestamp_ns = timestamp_ns;
+
+  TRACE_EVENT ev = profiler_domain_.trace_event("LC & optimization", profiler_color_);
+
+  bool skip_loop_closure = false;
+  if (!last_loop_closures_stamped_.empty()) {
+    // no need for LC if previous LC was recent
+    if ((timestamp_ns - last_loop_closures_stamped_.back().timestamp_ns) < throttling_time_ns_) {
+      skip_loop_closure = true;  // loop closure not needed
+    }
+  }
+
+  //--- Loop Closure detection ---
+  if (loop_closure_solver_ == nullptr || skip_loop_closure) {
+    return;
+  }
+
+  LocalizerAndMapper::LoopClosureStatus lc_status;
+  bool lc_found = false;
+  {
+    std::lock_guard slam_guard(slam_mutex_);
+    slam_->DetectLoopClosure(*loop_closure_solver_, current_images, world_from_rig_guess, lc_status);
+    lc_found = lc_status.success;
+  }
+
+  // view loop closure
+  std::shared_ptr<ViewLandmarks> lc_view = loop_close_view_ ? loop_close_view_->acquire_earliest() : nullptr;
+  if (lc_view) {
+    std::lock_guard slam_guard(slam_mutex_);
+    PublishLoopClosureToView(slam_->GetMap(), lc_status.landmarks, *lc_view);
+    lc_view->timestamp_ns = timestamp_ns;
+    lc_view.reset();
+  }
+
+  // Update Landmark Statistic in spatial index
+  {
+    std::lock_guard slam_guard(slam_mutex_);
+    slam_->UpdateLandmarkProbeStatistics(lc_status.discarded_landmarks);
+  }
+  // Add LC edge and Add Landmark Relation to spatial index and pose graph
+  if (lc_found) {
+    std::lock_guard slam_guard(slam_mutex_);
+    if (slam_->ApplyLoopClosureResult(lc_status.result_pose, lc_status.result_pose_covariance, lc_status.landmarks)) {
+      const LoopClosureStamped lc_pose_stamped = {frame_id, timestamp_ns, lc_status.result_pose};
+      last_loop_closures_stamped_.push_back(lc_pose_stamped);
+      while (last_loop_closures_stamped_.size() > max_num_last_lcs_) {
+        last_loop_closures_stamped_.pop_front();
+      }
+    } else {
+      SlamStdout("Can't apply loop closure result");
+    }
+  }
+
+  last_step_telemetry.lc_status = lc_found;
+  last_step_telemetry.lc_selected_landmarks_count = lc_status.selected_landmarks_count;
+  last_step_telemetry.lc_tracked_landmarks_count = lc_status.tracked_landmarks_count;
+  last_step_telemetry.lc_pnp_landmarks_count = lc_status.pnp_landmarks_count;
+  last_step_telemetry.lc_good_landmarks_count = lc_status.good_landmarks_count;
+  if (lc_found) {
+    SlamStdout("S");  // Successful LC
+  }
+  // Slam Pose Graph Optimization
+  bool optimization_happens = false;
+  if (lc_found || options_.planar_constraints) {
+    // TODO: ? optimize_options.keyframes_in_sight = loop_closure_status.keyframes_in_sight;
+    std::lock_guard slam_guard(slam_mutex_);
+
+    optimization_happens = slam_->OptimizePoseGraph(options_.planar_constraints);
+  }
+  if (optimization_happens) {
+    const Isometry3T pose_estimate_slam = slam_->GetCurrentPose();
+    TRACE_EVENT ev1 = profiler_domain_.trace_event("post optimization", profiler_color_);
+    log::Value<LogFrames>("pose_slam", pose_estimate_slam);
+    last_step_telemetry.pgo_status = true;
+
+    int64_t last_keyframe_ts;
+    Isometry3T last_keyframe_pose;
+    if (slam_->GetLastKeyframePoseAndTimestamp(last_keyframe_pose, last_keyframe_ts)) {
+      if (!tail_.UpdatePoseBySLAM(last_keyframe_ts, last_keyframe_pose)) {
+        TraceWarning(
+            "Failed to update SLAM tail after pose graph optimization: keyframe timestamp is outside retention.");
+      }
+    }
+
+    SlamStdout(":");
+  }
+  telemetry_queue_.Push(std::make_shared<AsyncSlamLCTelemetry>(last_step_telemetry));
+}
+
+void AsyncSlam::PublishViews_worker(uint64_t timestamp_ns) {
+  // view landmarks
+  std::shared_ptr<ViewLandmarks> landmarks_view = landmarks_view_ ? landmarks_view_->acquire_earliest() : nullptr;
+  if (landmarks_view) {
+    std::lock_guard slam_guard(slam_mutex_);
+    landmarks_view->landmarks.clear();
+    PublishAllLandmarksToView(slam_->GetMap(), timestamp_ns, *landmarks_view);
+    landmarks_view.reset();
+  }
+
+  // view pose graph
+  std::shared_ptr<ViewPoseGraph> pose_graph_view = pose_graph_view_ ? pose_graph_view_->acquire_earliest() : nullptr;
+  if (pose_graph_view) {
+    std::lock_guard slam_guard(slam_mutex_);
+    PublishPoseGraphToView(slam_->GetMap(), timestamp_ns, *pose_graph_view);
+    pose_graph_view.reset();
+  }
+}
+
+void AsyncSlam::ProcessInput_worker() {
+  FrameId frame_id = InvalidFrameId;
+  uint64_t timestamp_ns = 0;
+  Isometry3T world_from_rig_guess;
+
+  const bool has_input = AddKeyframesAndRunCommands_worker(frame_id, timestamp_ns, world_from_rig_guess);
+  {
+    std::lock_guard slam_guard(slam_mutex_);
+    slam_->ReduceKeyframes();
+  }
+  if (!has_input) {
+    return;
+  }
+
+  Images current_images;
+  const bool is_valid_image = GetLatestProcessingImages_worker(frame_id, current_images);
+  if (is_valid_image) {
+    RunLoopClosureAndOptimization_worker(frame_id, timestamp_ns, world_from_rig_guess, current_images);
+  }
+
+  PublishViews_worker(timestamp_ns);
+
+  if (input_queue_.IsEmpty()) {
+    std::lock_guard slam_guard(slam_mutex_);
+    slam_->FlushActiveDatabase();
+  }
+}
+
+bool AsyncSlam::CopyToDatabase_worker(const std::string& path) {
+  const bool status = slam_->AttachToNewDatabaseSaveMapAndDetach(path);
+  if (copy_to_database_callback_) {
+    copy_to_database_callback_(status);
+  }
+  copy_to_database_callback_ = nullptr;
+  return status;
+}
+
+}  // namespace cuvslam::slam

--- a/libs/slam/async_slam/async_slam_worker.cpp
+++ b/libs/slam/async_slam/async_slam_worker.cpp
@@ -79,14 +79,7 @@ bool AsyncSlam::AddKeyframesAndRunCommands_worker(FrameId& frame_id, uint64_t& t
     }
 
     Images current_images;
-    {
-      std::lock_guard image_guard(processing_images_mutex_);
-      current_images = processing_images_;
-    }
-    const auto current_image =
-        std::find_if(current_images.begin(), current_images.end(), [](const auto& image) { return image != nullptr; });
-    const bool is_valid_image =
-        current_image != current_images.end() && ((*current_image)->get_image_meta().frame_id == frame_data.frame_id);
+    const bool is_valid_image = GetLatestProcessingImages_worker(frame_data.frame_id, current_images);
     Isometry3T pose_estimate_slam;
     {
       const VOTrackData& track_data = vo_kf->track_data;


### PR DESCRIPTION
eparates the methods that run on the SLAM worker thread (_worker suffix) from the caller-facing API, and tightens const-correctness on state that never changes after construction, to make the threading model easier to reason about and to close a static-analysis backlog (CLion/Clang-Tidy).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous SLAM processing for queued keyframes and commands.
  * Added loop-closure detection, pose-graph optimization, and updated landmark and pose views.
  * Added support for saving SLAM data to a new database with progress callbacks.
  * Added background telemetry updates and database maintenance.

* **Bug Fixes**
  * Improved handling of invalid, unavailable, or stale tracking, image, and camera data.
  * Improved database flushing during idle periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->