### PR TITLE
[fix] Avoid unnecessary mutex contention in GetSlamPose()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Unnecessary mutex contention in `AsyncSlam::GetSlamPose()`
+
 ## [17.0.0] - 2026-07-21
 
 Adds cuNLS-based multisensor fusion, improves tracking and SLAM robustness, and expands evaluation tooling.

--- a/libs/slam/async_slam/async_slam.cpp
+++ b/libs/slam/async_slam/async_slam.cpp
@@ -211,13 +211,12 @@ void AsyncSlam::TrackResult(FrameId frameId, int64_t timestamp_ns, const odom::I
 }
 
 Isometry3T AsyncSlam::GetSlamPose() const {
-  std::lock_guard slam_guard(slam_mutex_);
-  const auto may_be_tip = tail_.GetTip();
+  const auto may_be_tip = tail_.GetTip();  // thread-safe
   if (!may_be_tip) {
     return Isometry3T::Identity();
   }
   const Isometry3T& tail_tip = may_be_tip->second;
-  Isometry3T slam_pose = tail_tip * track_data_.from_keyframe;
+  Isometry3T slam_pose = tail_tip * track_data_.from_keyframe;  // track_data_ touched only in main thread
 
   if (options_.planar_constraints) {
     slam_pose.translation().y() = 0;

--- a/libs/slam/test/async_slam_concurrency_test.cpp
+++ b/libs/slam/test/async_slam_concurrency_test.cpp
@@ -73,6 +73,114 @@ cuvslam::Slam::LocalizationSettings MakeLocalizationSettings() {
 
 }  // namespace
 
+TEST(AsyncSlam, GetSlamPose_ReturnsIdentityBeforeAnyTrackResult) {
+  std::unique_ptr<cuvslam::camera::ICameraModel> camera;
+  const cuvslam::camera::Rig rig = MakeSingleCameraRig(camera);
+  cuvslam::slam::AsyncSlamOptions options;
+  options.use_gpu = false;
+  options.reproduce_mode = true;
+  options.loop_closure_solver_type = cuvslam::slam::LoopClosureSolverType::kDummy;
+
+  cuvslam::slam::AsyncSlam slam(rig, {0}, options);
+
+  EXPECT_TRUE(slam.GetSlamPose().isApprox(cuvslam::Isometry3T::Identity()));
+}
+
+TEST(AsyncSlam, GetSlamPose_ComposesTailTipWithTrackDataFromKeyframe) {
+  std::unique_ptr<cuvslam::camera::ICameraModel> camera;
+  const cuvslam::camera::Rig rig = MakeSingleCameraRig(camera);
+  cuvslam::slam::AsyncSlamOptions options;
+  options.use_gpu = false;
+  options.reproduce_mode = true;
+  options.loop_closure_solver_type = cuvslam::slam::LoopClosureSolverType::kDummy;
+
+  cuvslam::slam::AsyncSlam slam(rig, {0}, options);
+
+  // First keyframe: tail gets {ts=1000, Identity}; track_data_ is reset to Identity afterwards.
+  cuvslam::odom::IVisualOdometry::VOFrameStat keyframe_stat{};
+  keyframe_stat.keyframe = true;
+  slam.TrackResult(1, 1'000, keyframe_stat, MakeImages(1, 1'000), cuvslam::Isometry3T::Identity());
+  EXPECT_TRUE(slam.GetSlamPose().isApprox(cuvslam::Isometry3T::Identity()));
+
+  // Non-keyframe with delta z=3: track_data_.from_keyframe accumulates the delta.
+  // GetSlamPose() = tail_tip (Identity) * delta = translation z=3.
+  cuvslam::odom::IVisualOdometry::VOFrameStat nonkey_stat{};
+  nonkey_stat.keyframe = false;
+  cuvslam::Isometry3T delta = cuvslam::Isometry3T::Identity();
+  delta.translation().z() = 3.f;
+  slam.TrackResult(2, 2'000, nonkey_stat, {}, delta);
+
+  const cuvslam::Isometry3T pose = slam.GetSlamPose();
+  EXPECT_NEAR(pose.translation().z(), 3.f, 1e-5f);
+  EXPECT_NEAR(pose.translation().x(), 0.f, 1e-5f);
+}
+
+TEST(AsyncSlam, GetSlamPose_CalledFromCallerThreadAfterTrackResult_ReturnsConsistentPose) {
+  // Verifies the single-threaded calling convention: GetSlamPose() is called from the same
+  // thread as TrackResult(), so track_data_ is safe to read without additional locking.
+  std::unique_ptr<cuvslam::camera::ICameraModel> camera;
+  const cuvslam::camera::Rig rig = MakeSingleCameraRig(camera);
+  cuvslam::slam::AsyncSlamOptions options;
+  options.use_gpu = false;
+  options.reproduce_mode = true;
+  options.loop_closure_solver_type = cuvslam::slam::LoopClosureSolverType::kDummy;
+
+  cuvslam::slam::AsyncSlam slam(rig, {0}, options);
+
+  cuvslam::odom::IVisualOdometry::VOFrameStat keyframe_stat{};
+  keyframe_stat.keyframe = true;
+  slam.TrackResult(1, 1'000, keyframe_stat, MakeImages(1, 1'000), cuvslam::Isometry3T::Identity());
+
+  cuvslam::Isometry3T delta = cuvslam::Isometry3T::Identity();
+  delta.translation().x() = 5.f;
+  slam.TrackResult(2, 2'000, {}, {}, delta);
+
+  const cuvslam::Isometry3T pose = slam.GetSlamPose();
+  EXPECT_TRUE(pose.matrix().allFinite());
+  EXPECT_NEAR(pose.translation().x(), 5.f, 1e-5f);
+}
+
+TEST(AsyncSlam, GetSlamPose_AsyncMode_ReturnsIdentityBeforeAnyTrackResult) {
+  std::unique_ptr<cuvslam::camera::ICameraModel> camera;
+  const cuvslam::camera::Rig rig = MakeSingleCameraRig(camera);
+  cuvslam::slam::AsyncSlamOptions options;
+  options.use_gpu = false;
+  options.reproduce_mode = false;
+  options.loop_closure_solver_type = cuvslam::slam::LoopClosureSolverType::kDummy;
+
+  cuvslam::slam::AsyncSlam slam(rig, {0}, options);
+
+  EXPECT_TRUE(slam.GetSlamPose().isApprox(cuvslam::Isometry3T::Identity()));
+}
+
+TEST(AsyncSlam, GetSlamPose_AsyncMode_IsFiniteAndCorrectAfterTrackResult) {
+  // tail and track_data_ are both updated in TrackResult() on the caller thread, so
+  // GetSlamPose() is immediately correct without waiting for the background thread.
+  std::unique_ptr<cuvslam::camera::ICameraModel> camera;
+  const cuvslam::camera::Rig rig = MakeSingleCameraRig(camera);
+  cuvslam::slam::AsyncSlamOptions options;
+  options.use_gpu = false;
+  options.reproduce_mode = false;
+  options.loop_closure_solver_type = cuvslam::slam::LoopClosureSolverType::kDummy;
+
+  cuvslam::slam::AsyncSlam slam(rig, {0}, options);
+
+  cuvslam::odom::IVisualOdometry::VOFrameStat keyframe_stat{};
+  keyframe_stat.keyframe = true;
+  slam.TrackResult(1, 1'000, keyframe_stat, MakeImages(1, 1'000), cuvslam::Isometry3T::Identity());
+  EXPECT_TRUE(slam.GetSlamPose().matrix().allFinite());
+
+  // Non-keyframe with delta z=7: track_data_.from_keyframe is updated in the caller thread,
+  // so GetSlamPose() reflects it immediately.
+  cuvslam::Isometry3T delta = cuvslam::Isometry3T::Identity();
+  delta.translation().z() = 7.f;
+  slam.TrackResult(2, 2'000, {}, {}, delta);
+
+  const cuvslam::Isometry3T pose = slam.GetSlamPose();
+  EXPECT_TRUE(pose.matrix().allFinite());
+  EXPECT_NEAR(pose.translation().z(), 7.f, 1e-5f);
+}
+
 TEST(AsyncSlam, TrackResultCanRunWhileLocalizeInMapIsInFlight) {
   std::unique_ptr<cuvslam::camera::ICameraModel> camera;
   const cuvslam::camera::Rig rig = MakeSingleCameraRig(camera);


### PR DESCRIPTION
GetSlamPose() took slam_mutex_ despite never touching slam_ — its only state (tail_, track_data_) is either already independently thread-safe or only ever accessed from the caller's thread. Since this is a hot-path call made every frame, the lock only added needless contention with the background worker thread's much heavier slam_mutex_ critical sections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary synchronization during pose retrieval.
  * Improved responsiveness by minimizing contention when accessing odometry and tracking data.
  * Improved pose retrieval consistency and reliability across tracking modes.
  * Pose composition and planar movement behavior remain unchanged.

* **Documentation**
  * Added an Unreleased changelog entry describing the synchronization improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->