### PR TITLE
[fix] Speed up PGO solver

### DIFF
--- a/libs/math/pgo.cpp
+++ b/libs/math/pgo.cpp
@@ -468,7 +468,7 @@ bool PGO::pgo_planar(PGOInput& inputs, int max_iterations) const {
 
   int32_t num_iterations = 0;
 
-  Eigen::SimplicialLDLT<Eigen::SparseMatrix<float>, Eigen::Upper, Eigen::NaturalOrdering<int>> solver;
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<float>, Eigen::Upper> solver;
 
   do {
     ++num_iterations;
@@ -590,7 +590,7 @@ bool PGO::pgo_regular(PGOInput& inputs, int max_iterations) const {
 
   int32_t num_iterations = 0;
 
-  Eigen::SimplicialLDLT<Eigen::SparseMatrix<float>, Eigen::Upper, Eigen::NaturalOrdering<int>> solver;
+  Eigen::SimplicialLDLT<Eigen::SparseMatrix<float>, Eigen::Upper> solver;
 
   do {
     ++num_iterations;


### PR DESCRIPTION
SimplicialLDLT in pgo_planar/pgo_regular explicitly requested NaturalOrdering<int>, i.e. no fill-in reduction before factorizing the sparse Hessian. For 300 poses this caused heavy fill-in during the Cholesky factorization, making max PGO time 746ms.

Switching to the default AMDOrdering<int> reorders variables to minimize fill-in before factorization, cutting max PGO time to 38ms for the same 300-pose case. solve() still returns the solution in original variable order since Eigen applies the permutation internally, so no other code needed to change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal sparse solver configuration to use Eigen’s default ordering.
  * No user-visible behavior or performance changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->