### PR TITLE
[fix] Reduce evaluation log volume

### DIFF
--- a/scripts/provision_dataset.sh
+++ b/scripts/provision_dataset.sh
@@ -116,6 +116,6 @@ if [ "$DRY_RUN" = "true" ]; then
 fi
 
 echo "=== Uploading to $s3_tarball ==="
-aws s3 cp "$tarball" "$s3_tarball"
+aws s3 cp "$tarball" "$s3_tarball" --no-progress
 aws s3 ls "$s3_tarball" --summarize
 echo "Provision complete: $s3_tarball"

--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -60,7 +60,7 @@ stage_one() {
   fi
 
   echo "Staging $name from $s3_uri -> $dest"
-  aws s3 cp "$s3_uri" "$tmp_tar"
+  aws s3 cp "$s3_uri" "$tmp_tar" --no-progress
   rm -rf "$dest"
   mkdir -p "$dest"
   tar -xf "$tmp_tar" -C "$dest"

--- a/tools/python_tools/cuvslam_tools/tracker/cli.py
+++ b/tools/python_tools/cuvslam_tools/tracker/cli.py
@@ -83,6 +83,11 @@ def add_tracker_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--save_output_tracker_data", action="store_true", help="Save output tracker data.")
     parser.add_argument(
+        "--print_config",
+        action="store_true",
+        help="Print the complete odometry and SLAM configurations.",
+    )
+    parser.add_argument(
         "--visualize_rerun",
         action="store_true",
         help="Enable real-time visualization of tracking results using Rerun viewer.",

--- a/tools/python_tools/cuvslam_tools/tracker/dataset_reader.py
+++ b/tools/python_tools/cuvslam_tools/tracker/dataset_reader.py
@@ -154,9 +154,7 @@ class DatasetReader:
     def parse_config(config_data: dict) -> vslam.Rig:
         """Parse stereo.edex rig configuration into a cuVSLAM Rig."""
         try:
-            rig = DatasetReader.get_rig(config_data[0])
-            print("Rig initialized successfully.")
-            return rig
+            return DatasetReader.get_rig(config_data[0])
         except Exception as e:
             print(f"Error initializing Rig: {e}")
             raise

--- a/tools/python_tools/cuvslam_tools/tracker/edex_reader.py
+++ b/tools/python_tools/cuvslam_tools/tracker/edex_reader.py
@@ -559,10 +559,6 @@ class EdexReader(DatasetReader):
             rgbd_settings.depth_scale_factor = depth_scale_factor
             rgbd_settings.enable_depth_stereo_tracking = enable_depth_stereo_tracking
 
-            print(f"RGBD settings parsed: depth_camera_id={depth_camera_id}, "
-                  f"depth_scale_factor={depth_scale_factor}, "
-                  f"enable_depth_stereo_tracking={enable_depth_stereo_tracking}")
-
             return rgbd_settings
 
         except (KeyError, IndexError, TypeError) as e:

--- a/tools/python_tools/cuvslam_tools/tracker/runner.py
+++ b/tools/python_tools/cuvslam_tools/tracker/runner.py
@@ -112,10 +112,13 @@ class Tracker:
             if args.visualize_rerun:
                 self.slam_cfg.enable_reading_internals = True
 
-        print(
-            f"cuVSLAM version: {vslam.get_version()}\nOdometry config:\n{conv.to_str(self.odom_cfg)}")
-        if self.slam_cfg:
-            print(f"SLAM config:\n{conv.to_str(self.slam_cfg)}")
+        if getattr(args, "print_config", False):
+            print(
+                f"cuVSLAM version: {vslam.get_version()}\n"
+                f"Odometry config:\n{conv.to_str(self.odom_cfg)}"
+            )
+            if self.slam_cfg:
+                print(f"SLAM config:\n{conv.to_str(self.slam_cfg)}")
 
         self.stat = Stat()
         self.stat.odometry_mode = str(self.odom_cfg.odometry_mode)

--- a/tools/python_tools/cuvslam_tools/tracker/runner.py
+++ b/tools/python_tools/cuvslam_tools/tracker/runner.py
@@ -112,7 +112,7 @@ class Tracker:
             if args.visualize_rerun:
                 self.slam_cfg.enable_reading_internals = True
 
-        if getattr(args, "print_config", False):
+        if args.print_config:
             print(
                 f"cuVSLAM version: {vslam.get_version()}\n"
                 f"Odometry config:\n{conv.to_str(self.odom_cfg)}"

--- a/tools/python_tools/cuvslam_tools/tracker/runner.py
+++ b/tools/python_tools/cuvslam_tools/tracker/runner.py
@@ -191,9 +191,10 @@ class Tracker:
         # Set enable_depth_stereo_tracking (default: False)
         rgbd_settings.enable_depth_stereo_tracking = getattr(args, 'enable_depth_stereo_tracking', False)
 
-        print(f"RGBD settings initialized: depth_camera_id={rgbd_settings.depth_camera_id}, "
-              f"depth_scale_factor={rgbd_settings.depth_scale_factor}, "
-              f"enable_depth_stereo_tracking={rgbd_settings.enable_depth_stereo_tracking}")
+        if args.print_config:
+            print(f"RGBD settings initialized: depth_camera_id={rgbd_settings.depth_camera_id}, "
+                  f"depth_scale_factor={rgbd_settings.depth_scale_factor}, "
+                  f"enable_depth_stereo_tracking={rgbd_settings.enable_depth_stereo_tracking}")
 
         return rgbd_settings
 


### PR DESCRIPTION
Suppress S3 transfer progress (88k lines just for kitti) and make per-worker tracker configuration output opt-in via --print_config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to display complete odometry, SLAM, and RGBD configuration details when launching the tracker.

* **Bug Fixes**
  * Reduced unnecessary console output during dataset uploads and staging.
  * Configuration details and setup diagnostics are no longer printed by default; they appear only when explicitly requested.
  * Error reporting remains available when configuration parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->