### PR TITLE
[feat] PoseGraph::Optimize: BFS subgraph optimization from head keyframe

### DIFF
--- a/libs/slam/map/pose_graph/pose_graph.cpp
+++ b/libs/slam/map/pose_graph/pose_graph.cpp
@@ -54,7 +54,7 @@ void PoseGraphKeyFrame::AddKeyframeTransform(const Isometry3T& me, const Isometr
 
 float PoseGraphEdgeStat::Weight() const { return static_cast<float>(tracks3d_number); }
 
-PoseGraph::PoseGraph() = default;
+PoseGraph::PoseGraph(size_t max_keyframes_to_optimize) : max_keyframes_to_optimize_(max_keyframes_to_optimize) {}
 
 PoseGraph::~PoseGraph() { SlamStdout("Destroyed PoseGraph instance. "); }
 
@@ -136,10 +136,8 @@ void PoseGraph::RemoveKeyframe(KeyFrameId keyframe_id) {
   TRACE_EVENT ev = profiler_domain_.trace_event("RemoveKeyframe", profiler_color_);
   // remove all edges with keyframe_id
   std::vector<std::pair<KeyFrameId, KeyFrameId>> edge_pairs;
-  QueryKeyframeEdges(keyframe_id,
-                     [&](KeyFrameId from_keyframe, KeyFrameId to_keyframe, const Isometry3T&, const Matrix6T&) {
-                       edge_pairs.push_back({from_keyframe, to_keyframe});
-                     });
+  QueryKeyframeEdges(keyframe_id, [&](KeyFrameId from_keyframe, KeyFrameId to_keyframe, const Isometry3T&,
+                                      const Matrix6T&) { edge_pairs.push_back({from_keyframe, to_keyframe}); });
 
   for (const auto& edge_pair : edge_pairs) {
     const KeyFrameId from_keyframe = edge_pair.first;

--- a/libs/slam/map/pose_graph/pose_graph.cpp
+++ b/libs/slam/map/pose_graph/pose_graph.cpp
@@ -136,8 +136,10 @@ void PoseGraph::RemoveKeyframe(KeyFrameId keyframe_id) {
   TRACE_EVENT ev = profiler_domain_.trace_event("RemoveKeyframe", profiler_color_);
   // remove all edges with keyframe_id
   std::vector<std::pair<KeyFrameId, KeyFrameId>> edge_pairs;
-  QueryKeyframeEdges(keyframe_id, [&](KeyFrameId from_keyframe, KeyFrameId to_keyframe, const Isometry3T&,
-                                      const Matrix6T&) { edge_pairs.push_back({from_keyframe, to_keyframe}); });
+  QueryKeyframeEdges(keyframe_id,
+                     [&](KeyFrameId from_keyframe, KeyFrameId to_keyframe, const Isometry3T&, const Matrix6T&) {
+                       edge_pairs.push_back({from_keyframe, to_keyframe});
+                     });
 
   for (const auto& edge_pair : edge_pairs) {
     const KeyFrameId from_keyframe = edge_pair.first;

--- a/libs/slam/map/pose_graph/pose_graph.h
+++ b/libs/slam/map/pose_graph/pose_graph.h
@@ -103,7 +103,9 @@ public:
 
   // Optimize pose graph
   // Runs BFS from the head (tail) keyframe, collects up to max_keyframes_to_optimize_ keyframes,
-  // and optimizes that subgraph. The head keyframe is used as the fixed pose constraint.
+  // and optimizes that subgraph. Boundary nodes (connected to the subgraph but outside it) are
+  // pinned as fixed constraints; when the entire graph fits in the window, the oldest keyframe
+  // (smallest ID) is pinned as the fallback reference.
   // OUT: vo_to_head - transform for last keyframe
   bool Optimize(const PoseGraphHypothesis& pose_graph_hypothesis_src, PoseGraphHypothesis& pose_graph_hypothesis_dst,
                 bool planar_constraint, Isometry3T& vo_to_head) const;

--- a/libs/slam/map/pose_graph/pose_graph.h
+++ b/libs/slam/map/pose_graph/pose_graph.h
@@ -60,7 +60,7 @@ struct PoseGraphEdgeStat {
 
 class PoseGraph {
 public:
-  PoseGraph();
+  explicit PoseGraph(size_t max_keyframes_to_optimize = 300);
   ~PoseGraph();
 
   PoseGraph(const PoseGraph&) = delete;
@@ -102,6 +102,8 @@ public:
                  const PoseGraphEdgeStat* stat = nullptr);
 
   // Optimize pose graph
+  // Runs BFS from the head (tail) keyframe, collects up to max_keyframes_to_optimize_ keyframes,
+  // and optimizes that subgraph. The head keyframe is used as the fixed pose constraint.
   // OUT: vo_to_head - transform for last keyframe
   bool Optimize(const PoseGraphHypothesis& pose_graph_hypothesis_src, PoseGraphHypothesis& pose_graph_hypothesis_dst,
                 bool planar_constraint, Isometry3T& vo_to_head) const;
@@ -189,6 +191,8 @@ private:
   // tail
   KeyFrameId head_keyframe_id_ = InvalidKeyFrameId;
 
+  size_t max_keyframes_to_optimize_;
+
   // latest keyframes to guard in FindHardestEdge()
   size_t max_latest_keyframes_ = 20;
   std::list<KeyFrameId> latest_keyframes_;
@@ -200,6 +204,9 @@ private:
   mutable std::vector<EdgeId> edges_to_optimize_;
   mutable std::vector<KeyFrameId> constrained_keyframes_;
   mutable math::PGOInput inputs_;
+  // scratch buffers for BFS: neighbor collection and sorted merge output
+  mutable std::vector<KeyFrameId> bfs_visited_;
+  mutable std::vector<KeyFrameId> bfs_merge_buffer_;
 
   bool OptimizeSubgraph(const std::vector<KeyFrameId>& keyframes_to_optimize,
                         const std::vector<EdgeId>& edges_to_optimize,

--- a/libs/slam/map/pose_graph/pose_graph_optimize.cpp
+++ b/libs/slam/map/pose_graph/pose_graph_optimize.cpp
@@ -194,6 +194,9 @@ bool PoseGraph::Optimize(const PoseGraphHypothesis& pose_graph_hypothesis_src,
   // edges_to_optimize_: nodes added in the previous level, to be expanded next (sorted).
   // bfs_visited_: raw neighbor scratch buffer for the current level.
   // bfs_merge_buffer_: merge output buffer, swapped in and cleared each level.
+  if (max_keyframes_to_optimize_ == 0) {
+    return false;
+  }
   keyframes_to_optimize_.reserve(max_keyframes_to_optimize_);
   edges_to_optimize_.reserve(max_keyframes_to_optimize_);
   keyframes_to_optimize_.push_back(start_keyframe);
@@ -218,8 +221,10 @@ bool PoseGraph::Optimize(const PoseGraphHypothesis& pose_graph_hypothesis_src,
     std::set_difference(bfs_visited_.begin(), bfs_visited_.end(), keyframes_to_optimize_.begin(),
                         keyframes_to_optimize_.end(), std::back_inserter(edges_to_optimize_));
 
-    // Trim to remaining capacity
-    const size_t remaining = max_keyframes_to_optimize_ - keyframes_to_optimize_.size();
+    // Trim to remaining capacity (saturating to avoid size_t underflow)
+    const size_t remaining = max_keyframes_to_optimize_ > keyframes_to_optimize_.size()
+                                 ? max_keyframes_to_optimize_ - keyframes_to_optimize_.size()
+                                 : 0;
     if (edges_to_optimize_.size() > remaining) {
       edges_to_optimize_.resize(remaining);
     }

--- a/libs/slam/map/pose_graph/pose_graph_optimize.cpp
+++ b/libs/slam/map/pose_graph/pose_graph_optimize.cpp
@@ -15,6 +15,7 @@
  * of the software or derivative works thereof, you agree to be bound by this License.
  */
 
+#include <algorithm>
 #include <exception>
 
 #include "common/log_types.h"
@@ -177,28 +178,110 @@ bool PoseGraph::Optimize(const PoseGraphHypothesis& pose_graph_hypothesis_src,
                          PoseGraphHypothesis& pose_graph_hypothesis_dst, bool planar_constraint,
                          Isometry3T& vo_to_head) const {
   keyframes_to_optimize_.clear();
-  keyframes_to_optimize_.reserve(keyframes_.size());
-  for (const auto& it : keyframes_) {
-    keyframes_to_optimize_.push_back(it.first);
-  }
-
   edges_to_optimize_.clear();
-  edges_to_optimize_.reserve(edges_.size());
-  for (const auto& it : edges_) {
-    edges_to_optimize_.push_back(it.first);
+  constrained_keyframes_.clear();
+  bfs_visited_.clear();
+  bfs_merge_buffer_.clear();
+
+  KeyFrameId start_keyframe;
+  if (!GetHeadKeyframe(start_keyframe)) {
+    return false;
   }
 
-  constrained_keyframes_.clear();
-  KeyFrameId min_keyframe_id = InvalidKeyFrameId;
-  for (const KeyFrameId keyframe_id : keyframes_to_optimize_) {
-    if (min_keyframe_id == InvalidKeyFrameId || keyframe_id < min_keyframe_id) {
-      min_keyframe_id = keyframe_id;
+  // Level-based BFS — O(K*d*log K) worst case, no hash collisions.
+  // K = max_keyframes_to_optimize_, d = avg node degree.
+  // keyframes_to_optimize_: sorted visited set, grown each level via merge.
+  // edges_to_optimize_: nodes added in the previous level, to be expanded next (sorted).
+  // bfs_visited_: raw neighbor scratch buffer for the current level.
+  // bfs_merge_buffer_: merge output buffer, swapped in and cleared each level.
+  keyframes_to_optimize_.reserve(max_keyframes_to_optimize_);
+  edges_to_optimize_.reserve(max_keyframes_to_optimize_);
+  keyframes_to_optimize_.push_back(start_keyframe);
+  edges_to_optimize_.push_back(start_keyframe);
+
+  while (!edges_to_optimize_.empty() && keyframes_to_optimize_.size() < max_keyframes_to_optimize_) {
+    // Collect all neighbors of nodes added in the previous level into bfs_visited_
+    bfs_visited_.clear();
+    for (const KeyFrameId frontier_node : edges_to_optimize_) {
+      auto collect_neighbor = [&](KeyFrameId from, KeyFrameId to, const Isometry3T&, const Matrix6T&) {
+        bfs_visited_.push_back((from == frontier_node) ? to : from);
+      };
+      QueryKeyframeEdges(frontier_node, collect_neighbor);
+    }
+
+    // Sort + dedup raw neighbors — O(L*d*log(L*d)), L = nodes expanded this level, d = avg degree
+    std::sort(bfs_visited_.begin(), bfs_visited_.end());
+    bfs_visited_.erase(std::unique(bfs_visited_.begin(), bfs_visited_.end()), bfs_visited_.end());
+
+    // New level = unvisited neighbors (set_difference of two sorted ranges) — O(K)
+    edges_to_optimize_.clear();
+    std::set_difference(bfs_visited_.begin(), bfs_visited_.end(), keyframes_to_optimize_.begin(),
+                        keyframes_to_optimize_.end(), std::back_inserter(edges_to_optimize_));
+
+    // Trim to remaining capacity
+    const size_t remaining = max_keyframes_to_optimize_ - keyframes_to_optimize_.size();
+    if (edges_to_optimize_.size() > remaining) {
+      edges_to_optimize_.resize(remaining);
+    }
+    if (edges_to_optimize_.empty()) {
+      break;
+    }
+
+    // Merge sorted visited set + sorted new level into visited set — O(K)
+    std::merge(keyframes_to_optimize_.begin(), keyframes_to_optimize_.end(), edges_to_optimize_.begin(),
+               edges_to_optimize_.end(), std::back_inserter(bfs_merge_buffer_));
+    std::swap(keyframes_to_optimize_, bfs_merge_buffer_);
+    bfs_merge_buffer_.clear();
+  }
+
+  // keyframes_to_optimize_[0..bfs_count) is the sorted BFS subgraph
+  const size_t bfs_count = keyframes_to_optimize_.size();
+  edges_to_optimize_.clear();
+
+  auto in_bfs = [&](KeyFrameId kf) {
+    return std::binary_search(keyframes_to_optimize_.begin(), keyframes_to_optimize_.begin() + bfs_count, kf);
+  };
+
+  // Collect subgraph edges; append boundary nodes to constrained_keyframes_ (dedup deferred)
+  for (size_t i = 0; i < bfs_count; i++) {
+    const KeyFrameId current = keyframes_to_optimize_[i];
+    auto collect_edge = [&](KeyFrameId from, KeyFrameId to, const Isometry3T&, const Matrix6T&) {
+      const bool from_in = in_bfs(from);
+      const bool to_in = in_bfs(to);
+      if (!from_in && !to_in) {
+        return;
+      }
+      if (from_in && to_in && from != current) {
+        return;  // canonical direction: skip internal edges from the to-side
+      }
+      edges_to_optimize_.push_back(edges_from_to_.at({from, to}));
+      if (from_in && to_in) {
+        return;
+      }
+      constrained_keyframes_.push_back(from_in ? to : from);  // boundary node, dedup below
+    };
+    QueryKeyframeEdges(current, collect_edge);
+  }
+
+  // Dedup constrained_keyframes_ — O(B*log B), B = number of boundary nodes
+  std::sort(constrained_keyframes_.begin(), constrained_keyframes_.end());
+  constrained_keyframes_.erase(std::unique(constrained_keyframes_.begin(), constrained_keyframes_.end()),
+                               constrained_keyframes_.end());
+
+  // When the whole graph fits in the subgraph there are no boundary nodes; pin the oldest
+  // keyframe (min ID, index 0 in sorted keyframes_to_optimize_) as the fixed reference.
+  if (constrained_keyframes_.empty() && bfs_count > 0) {
+    constrained_keyframes_.push_back(keyframes_to_optimize_[0]);
+  }
+
+  // Append constraint nodes to keyframes_to_optimize_ for OptimizeSubgraph.
+  // Boundary nodes are outside the BFS subgraph and must be appended.
+  // The fallback constraint (oldest BFS node) is already in the subgraph — skip it.
+  for (const KeyFrameId kf : constrained_keyframes_) {
+    if (!std::binary_search(keyframes_to_optimize_.begin(), keyframes_to_optimize_.begin() + bfs_count, kf)) {
+      keyframes_to_optimize_.push_back(kf);
     }
   }
-  if (min_keyframe_id == InvalidKeyFrameId) {
-    return false;  // nothing to optimize
-  }
-  constrained_keyframes_.push_back(min_keyframe_id);
 
   return OptimizeSubgraph(keyframes_to_optimize_, edges_to_optimize_, constrained_keyframes_, pose_graph_hypothesis_src,
                           planar_constraint, pose_graph_hypothesis_dst, vo_to_head);

--- a/libs/slam/test/CMakeLists.txt
+++ b/libs/slam/test/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCES
     pgo_test.cpp
     p3p_test.cpp
     pnp_ransac_test.cpp
-rigid_transform_3d_test.cpp
+    rigid_transform_3d_test.cpp
     slam_test.cpp
     tail_test.cpp
     thread_safe_queue_test.cpp

--- a/libs/slam/test/CMakeLists.txt
+++ b/libs/slam/test/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SOURCES
     pgo_test.cpp
     p3p_test.cpp
     pnp_ransac_test.cpp
-    rigid_transform_3d_test.cpp
+rigid_transform_3d_test.cpp
     slam_test.cpp
     tail_test.cpp
     thread_safe_queue_test.cpp

--- a/libs/slam/test/pgo_test.cpp
+++ b/libs/slam/test/pgo_test.cpp
@@ -19,8 +19,117 @@
 
 #include "common/include_gtest.h"
 #include "common/vector_3t.h"
+#include "slam/map/pose_graph/pose_graph.h"
+#include "slam/map/pose_graph/pose_graph_hypothesis.h"
 
 namespace test::slam {
+
+namespace {
+
+using namespace cuvslam;
+using namespace cuvslam::slam;
+
+Isometry3T PoseX(float x) {
+  Isometry3T p = Isometry3T::Identity();
+  p.translation().x() = x;
+  return p;
+}
+
+Matrix6T UniformCov(float diag) { return Matrix6T::Identity() * diag; }
+
+// Builds a linear chain of n keyframes, each separated by step_x in X.
+// Returns keyframe IDs in insertion order.
+std::vector<KeyFrameId> BuildChain(PoseGraph& pg, PoseGraphHypothesis& hyp, int n, float step_x) {
+  const Matrix6T cov = UniformCov(1.0f);
+  const Isometry3T step = PoseX(step_x);
+  std::vector<KeyFrameId> ids;
+  for (int i = 0; i < n; ++i) {
+    const Isometry3T* rel = (i > 0) ? &step : nullptr;
+    const Matrix6T* cov_ptr = (i > 0) ? &cov : nullptr;
+    const KeyFrameId id = pg.AddKeyframe(hyp, rel, cov_ptr, "", {});
+    hyp.SetKeyframePose(id, PoseX(i * step_x));
+    ids.push_back(id);
+  }
+  return ids;
+}
+
+}  // namespace
+
+// No keyframes added — nothing to optimize.
+TEST(PoseGraph, Optimize_NoKeyframes) {
+  PoseGraph pg;
+  PoseGraphHypothesis src, dst;
+  Isometry3T vo_to_head;
+  EXPECT_FALSE(pg.Optimize(src, dst, false, vo_to_head));
+}
+
+// Keyframes exist but no edges — optimizer has nothing to work with.
+TEST(PoseGraph, Optimize_NoEdges) {
+  PoseGraph pg;
+  PoseGraphHypothesis src, dst;
+  const KeyFrameId kf = pg.AddKeyframe(src, nullptr, nullptr, "", {});
+  src.SetKeyframePose(kf, Isometry3T::Identity());
+  Isometry3T vo_to_head;
+  EXPECT_FALSE(pg.Optimize(src, dst, false, vo_to_head));
+}
+
+// Fully consistent chain — no loop closure, optimizer makes no correction.
+TEST(PoseGraph, Optimize_ConsistentChain_VoToHeadIsIdentity) {
+  PoseGraph pg;
+  PoseGraphHypothesis src, dst;
+  BuildChain(pg, src, 6, 1.0f);
+
+  Isometry3T vo_to_head;
+  ASSERT_TRUE(pg.Optimize(src, dst, false, vo_to_head));
+  EXPECT_NEAR(vo_to_head.translation().norm(), 0.0f, 1e-3f);
+}
+
+// Chain with a loop closure that closes accumulated drift.
+// Optimizer should apply a non-trivial correction to the head node.
+TEST(PoseGraph, Optimize_LoopClosure_CorrectionApplied) {
+  constexpr int kN = 8;
+  constexpr float kStep = 1.0f;
+
+  PoseGraph pg;
+  PoseGraphHypothesis src, dst;
+  const auto ids = BuildChain(pg, src, kN, kStep);
+
+  // Inconsistent loop closure: 0.2-unit short of a perfect closure.
+  // Normalized residual = sqrt(info) * 0.2 = 0.2 < robustifier 0.5 — stays in linear regime.
+  const Isometry3T lc_rel = PoseX(-(kN - 1) * kStep + 0.2f);
+  pg.AddEdge(src, ids[kN - 1], ids[0], lc_rel, UniformCov(1.0f));
+
+  Isometry3T vo_to_head;
+  ASSERT_TRUE(pg.Optimize(src, dst, false, vo_to_head));
+  EXPECT_GT(vo_to_head.translation().norm(), 0.05f);
+}
+
+// With max_keyframes_to_optimize < N, BFS from the head reaches only a local subgraph.
+// The correction applied to the head differs from a full-graph optimization.
+TEST(PoseGraph, Optimize_BFSLimitsSubgraph) {
+  constexpr int kN = 10;
+  constexpr float kStep = 1.0f;
+
+  auto run = [&](size_t max_k) {
+    PoseGraph pg(max_k);
+    PoseGraphHypothesis src, dst;
+    const auto ids = BuildChain(pg, src, kN, kStep);
+    const Isometry3T lc_rel = PoseX(-(kN - 1) * kStep + 0.2f);
+    pg.AddEdge(src, ids[kN - 1], ids[0], lc_rel, UniformCov(1.0f));
+    Isometry3T vo_to_head;
+    EXPECT_TRUE(pg.Optimize(src, dst, false, vo_to_head));
+    return vo_to_head.translation().x();
+  };
+
+  const float correction_full = run(kN);  // all nodes in subgraph
+  const float correction_local = run(4);  // only 4 nodes near head
+
+  // Both optimizations see the loop closure (head is always in subgraph)
+  EXPECT_GT(std::abs(correction_full), 0.01f);
+  EXPECT_GT(std::abs(correction_local), 0.01f);
+  // Distributing the error over different subgraph sizes yields different corrections
+  EXPECT_GT(std::abs(correction_full - correction_local), 0.01f);
+}
 
 TEST(SlamTest, PGO) {
   Eigen::AlignedBox3f observer_box;


### PR DESCRIPTION
Replace full-graph PGO with a level-based BFS that collects up to
max_keyframes_to_optimize_ nodes starting from the head keyframe, then
optimizes that subgraph. Boundary nodes (connected to the subgraph but
outside it) are pinned as constraints; when the whole graph fits in the
window the oldest node is pinned as fallback reference.
Key algorithmic choices:

Level-based BFS with sort+merge per level: O(K·d·log K) worst case,
no hash collision risk.
Edge collection via canonical-direction skip: each internal edge
visited once, no dedup scan needed — O(K·d·log K).
Constraint dedup via sort+unique after collection: O(B·log B).
PoseGraph constructor exposes max_keyframes_to_optimize (default 300),
matching the existing max_pose_graph_nodes limit so behaviour is
identical to the previous full-graph code on typical trajectories.
Adds five PoseGraph::Optimize unit tests in pgo_test.cpp covering
empty graph, no edges, consistent chain, loop closure correction,
and BFS subgraph limiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pose-graph optimization now supports a configurable maximum optimization window.
  * Optimization selects a bounded subgraph around the latest keyframe, including relevant boundary constraints.
  * Added fallback handling for graphs without boundary constraints.

* **Bug Fixes**
  * Improved handling of empty graphs, disconnected chains, and loop closures.

* **Tests**
  * Added coverage for keyframe chains, optimization limits, loop-closure correction, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->