### PR TITLE
[infra] add commit title length rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ Load-bearing rules:
 - `[test]` — test-only changes, new or updated tests
 - `[infra]` — infrastructure not tied to product source code (for example `AGENTS.md`, repo configs, `.gitignore`)
 
+**Length:** Keep the git commit message title (the first line) to 70 characters or fewer.
+
 **Unit tests:** `[fix]` and `[feat]` MRs must include unit tests (C++ in `libs/*/test/` and/or Python under `python/test/` as appropriate).
 
 **Scope:** Do not mix several unrelated changes in one MR. Keep each MR as small as is reasonable; every change in the MR should clearly relate to its stated topic.


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a merge-request policy limiting commit-message titles to 70 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->