### PR TITLE
[fix] Stop NaN leaking from unchecked camera point conversions

### DIFF
--- a/libs/camera/camera.h
+++ b/libs/camera/camera.h
@@ -59,12 +59,12 @@ public:
                float max_normalized_uv_radius = 10000.f, float max_xy_radius = 10000.f);
   virtual ~ICameraModel() = default;
 
-  bool normalizePoint(const Vector2T& uv, Vector2T& xy) const;
-  bool denormalizePoint(const Vector2T& xy, Vector2T& uv) const;
+  [[nodiscard]] bool normalizePoint(const Vector2T& uv, Vector2T& xy) const;
+  [[nodiscard]] bool denormalizePoint(const Vector2T& xy, Vector2T& uv) const;
 
-  const Vector2T& getPrincipal() const;
-  const Vector2T& getFocal() const;
-  const Vector2T& getResolution() const;
+  [[nodiscard]] const Vector2T& getPrincipal() const;
+  [[nodiscard]] const Vector2T& getFocal() const;
+  [[nodiscard]] const Vector2T& getResolution() const;
 
 protected:  // for debug purpose, more specific implementation may want to compare result with generic one
   virtual bool distort(const Vector2T& xy, Vector2T& normalized_uv) const = 0;

--- a/libs/camera/observation.cpp
+++ b/libs/camera/observation.cpp
@@ -67,18 +67,28 @@ Matrix2T ObservationInfoUVToNormUV(const ICameraModel& intrinsics, const Matrix2
 }
 
 // xy must be equal to output of intrinsics.normalizePoint(uv)
-Matrix2T ObservationInfoUVToXY(const ICameraModel& intrinsics, const Vector2T& uv, const Vector2T& xy,
-                               const Matrix2T& info_uv) {
-  Matrix2T cov = info_uv.inverse();
-  Matrix2T cov_xy = math::approximate<2, 2>(
+bool ObservationInfoUVToXY(const ICameraModel& intrinsics, const Vector2T& uv, const Vector2T& xy,
+                           const Matrix2T& info_uv, Matrix2T& info_xy) {
+  // The jacobian is sampled around uv, so a sample can land outside the model even when uv itself
+  // is fine. Such a sample contributes a zero instead of a real value, which would quietly skew
+  // the result — report it rather than returning a plausible-looking matrix.
+  bool all_samples_valid = true;
+  const Matrix2T cov = info_uv.inverse();
+  const Matrix2T cov_xy = math::approximate<2, 2>(
       uv, xy, cov,
-      [&intrinsics](const Vector2T& in) {
-        Vector2T out;
-        intrinsics.normalizePoint(in, out);
+      [&intrinsics, &all_samples_valid](const Vector2T& in) {
+        Vector2T out = Vector2T::Zero();
+        if (!intrinsics.normalizePoint(in, out)) {
+          all_samples_valid = false;
+        }
         return out;
       },
       true /* is_lambda_affine */);
-  return cov_xy.inverse();
+  if (!all_samples_valid) {
+    return false;
+  }
+  info_xy = cov_xy.inverse();
+  return true;
 }
 
 }  // namespace cuvslam::camera

--- a/libs/camera/observation.h
+++ b/libs/camera/observation.h
@@ -47,7 +47,9 @@ bool FindObservation(const std::vector<Observation>& observations, TrackId track
 Matrix2T GetDefaultObservationInfoUV();
 
 Matrix2T ObservationInfoUVToNormUV(const ICameraModel& intrinsics, const Matrix2T& info_uv);
-Matrix2T ObservationInfoUVToXY(const ICameraModel& intrinsics, const Vector2T& uv, const Vector2T& xy,
-                               const Matrix2T& info_uv);
+// Fails when a sample of the numeric jacobian falls outside the camera model's validity — the
+// resulting matrix would be silently wrong. `info_xy` is left untouched in that case.
+[[nodiscard]] bool ObservationInfoUVToXY(const ICameraModel& intrinsics, const Vector2T& uv, const Vector2T& xy,
+                                         const Matrix2T& info_uv, Matrix2T& info_xy);
 
 }  // namespace cuvslam::camera

--- a/libs/slam/async_slam/async_slam.cpp
+++ b/libs/slam/async_slam/async_slam.cpp
@@ -180,7 +180,9 @@ void AsyncSlam::TrackResult(const FrameId frameId, const int64_t timestamp_ns,
           continue;
         }
         Vector2T uv_norm;
-        intrinsics->normalizePoint(uv, uv_norm);
+        if (!intrinsics->normalizePoint(uv, uv_norm)) {
+          continue;
+        }
         vo_keyframe->frame_data.tracks2d_norm.emplace_back(VOFrameData::Track2DXY{cam_id, track_id, uv_norm});
         added_tracks.insert(track_id);
       }

--- a/libs/sof/sof.h
+++ b/libs/sof/sof.h
@@ -114,8 +114,12 @@ public:
         continue;
       }
 
-      frameTracks.push_back(
-          {t.cam_id(), t.id(), xy, camera::ObservationInfoUVToXY(intrinsics, t.position(), xy, t.info())});
+      Matrix2T info_xy;
+      if (!camera::ObservationInfoUVToXY(intrinsics, t.position(), xy, t.info(), info_xy)) {
+        continue;
+      }
+
+      frameTracks.push_back({t.cam_id(), t.id(), xy, info_xy});
     }
   }
 

--- a/libs/sof/sof_mono_cpu.cpp
+++ b/libs/sof/sof_mono_cpu.cpp
@@ -249,6 +249,7 @@ void MonoSOFCPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
     // @TODO: come back and revisit to make sure we do normalization only once
     Vector2T v1, v2;  // in xy coordinates
     if (!intrinsics.normalizePoint(lastIt->position(), v1) || !intrinsics.normalizePoint(track.position(), v2)) {
+      tracks.kill(i);  // drop it, so the inlier loop below stays in step with sampleSequence
       continue;
     }
     sampleSequence.emplace_back(v1, v2);

--- a/libs/sof/sof_mono_cpu.cpp
+++ b/libs/sof/sof_mono_cpu.cpp
@@ -248,8 +248,9 @@ void MonoSOFCPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
     assert(lastIt != lastEnd);
     // @TODO: come back and revisit to make sure we do normalization only once
     Vector2T v1, v2;  // in xy coordinates
-    intrinsics.normalizePoint(lastIt->position(), v1);
-    intrinsics.normalizePoint(track.position(), v2);
+    if (!intrinsics.normalizePoint(lastIt->position(), v1) || !intrinsics.normalizePoint(track.position(), v2)) {
+      continue;
+    }
     sampleSequence.emplace_back(v1, v2);
 
 #ifdef DECREASE_RANSAC_AREA

--- a/libs/sof/sof_mono_gpu.cpp
+++ b/libs/sof/sof_mono_gpu.cpp
@@ -311,8 +311,9 @@ void MonoSOFGPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
     assert(lastIt != lastEnd);
     // @TODO: come back and revisit to make sure we do normalization only once
     Vector2T v1, v2;  // in xy coordinates
-    intrinsics.normalizePoint(lastIt->position(), v1);
-    intrinsics.normalizePoint(track.position(), v2);
+    if (!intrinsics.normalizePoint(lastIt->position(), v1) || !intrinsics.normalizePoint(track.position(), v2)) {
+      continue;
+    }
     sampleSequence.emplace_back(v1, v2);
 
 #ifdef DECREASE_RANSAC_AREA

--- a/libs/sof/sof_mono_gpu.cpp
+++ b/libs/sof/sof_mono_gpu.cpp
@@ -312,6 +312,7 @@ void MonoSOFGPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
     // @TODO: come back and revisit to make sure we do normalization only once
     Vector2T v1, v2;  // in xy coordinates
     if (!intrinsics.normalizePoint(lastIt->position(), v1) || !intrinsics.normalizePoint(track.position(), v2)) {
+      tracks.kill(i);  // drop it, so the inlier loop below stays in step with sampleSequence
       continue;
     }
     sampleSequence.emplace_back(v1, v2);

--- a/libs/sof/sof_multicamera_cpu.cpp
+++ b/libs/sof/sof_multicamera_cpu.cpp
@@ -81,7 +81,12 @@ void MultiSOFCPU::LaunchTrackingPrimaryToSecondary(CameraId primary_id, CameraId
 
   size_t max_candidates = 0;
   for (size_t i = 0; i < n; ++i) {
-    intrinsicsP.denormalizePoint(primary_obs[i].xy, uvL[i]);
+    // A point that can't be projected gets no candidates: Candidates() would otherwise leave last
+    // frame's list in place, and uvL[i] keeps whatever it held.
+    if (!intrinsicsP.denormalizePoint(primary_obs[i].xy, uvL[i])) {
+      cands[i].clear();
+      continue;
+    }
     epipolar_curves.Candidates(uvL[i], cands[i]);
     max_candidates = std::max(max_candidates, cands[i].size());
   }
@@ -120,9 +125,12 @@ void MultiSOFCPU::LaunchTrackingPrimaryToSecondary(CameraId primary_id, CameraId
         continue;
       }
       Vector2T xyR;
-      intrinsicsS.normalizePoint(winners[i].uvR, xyR);
-      secondary_obs->push_back({secondary_id, primary_obs[i].id, xyR,
-                                camera::ObservationInfoUVToXY(intrinsicsS, winners[i].uvR, xyR, winners[i].info)});
+      Matrix2T info_xy;
+      if (!intrinsicsS.normalizePoint(winners[i].uvR, xyR) ||
+          !camera::ObservationInfoUVToXY(intrinsicsS, winners[i].uvR, xyR, winners[i].info, info_xy)) {
+        continue;
+      }
+      secondary_obs->push_back({secondary_id, primary_obs[i].id, xyR, info_xy});
     }
   }
 }

--- a/libs/sof/sof_multicamera_gpu.cpp
+++ b/libs/sof/sof_multicamera_gpu.cpp
@@ -106,7 +106,13 @@ void MultiSOFGPU::LaunchTrackingPrimaryToSecondary(CameraId primary_id, CameraId
 
   size_t max_candidates = 0;
   for (size_t i = 0; i < n; ++i) {
-    intrinsicsP.denormalizePoint(primary_obs[i].xy, uvL[i]);
+    // A point that can't be projected gets no candidates: Candidates() would otherwise leave last
+    // frame's list in place, and uvL[i] still reaches the kernel as `data.track`.
+    if (!intrinsicsP.denormalizePoint(primary_obs[i].xy, uvL[i])) {
+      uvL[i].setZero();
+      cands[i].clear();
+      continue;
+    }
     epipolar_curves.Candidates(uvL[i], cands[i]);
     max_candidates = std::max(max_candidates, cands[i].size());
   }
@@ -219,10 +225,13 @@ void MultiSOFGPU::GetTrackingResults(MulticamObservations& observations) {
         if (data.track_status) {
           uvR << data.track.x, data.track.y;
           info << data.info[0], data.info[1], data.info[2], data.info[3];
-          intrinsicsS.normalizePoint(uvR, xyR);
+          Matrix2T info_xy;
+          if (!intrinsicsS.normalizePoint(uvR, xyR) ||
+              !camera::ObservationInfoUVToXY(intrinsicsS, uvR, xyR, info, info_xy)) {
+            continue;
+          }
 
-          secondary_observations[secondary_id].push_back(
-              {secondary_id, trackId, xyR, camera::ObservationInfoUVToXY(intrinsicsS, uvR, xyR, info)});
+          secondary_observations[secondary_id].push_back({secondary_id, trackId, xyR, info_xy});
         }
       }
     }

--- a/libs/sof/test/sof_l2r_test.cpp
+++ b/libs/sof/test/sof_l2r_test.cpp
@@ -59,8 +59,10 @@ void LogMatches(const std::string& name, const Sources& sources, const Metas& me
       }
       Vector2T uv_l;
       Vector2T uv_r;
-      rig.intrinsics[primary_id]->denormalizePoint(obs_l.xy, uv_l);
-      rig.intrinsics[secondary_id]->denormalizePoint(obs_r.xy, uv_r);
+      if (!rig.intrinsics[primary_id]->denormalizePoint(obs_l.xy, uv_l) ||
+          !rig.intrinsics[secondary_id]->denormalizePoint(obs_r.xy, uv_r)) {
+        break;
+      }
       strips.push_back(rerun::LineStrip2D({{uv_l.x(), uv_l.y()}, {uv_r.x() + static_cast<float>(w), uv_r.y()}}));
       break;
     }

--- a/tools/selection_visualizer/main.cpp
+++ b/tools/selection_visualizer/main.cpp
@@ -173,7 +173,9 @@ static void DoMonoTrack(const std::string& edexFile, std::string outputFolder, s
       const Color& c = trackColors.at(track.id);
 
       Vector2T uvL;
-      intrinsicsL.denormalizePoint(track.xy, uvL);
+      if (!intrinsicsL.denormalizePoint(track.xy, uvL)) {
+        continue;
+      }
       cv::circle(imgDrawL, cv::Point(uvL.x(), uvL.y()), 2, cv::Scalar(c.b, c.g, c.r), cv::FILLED);
     }
 

--- a/tools/sof_visualizer/main.cpp
+++ b/tools/sof_visualizer/main.cpp
@@ -71,7 +71,9 @@ void DrawCovariance(cv::Mat& dest, const camera::ICameraModel& intrinsics, const
                     cv::Scalar color) {
   Vector2T uv;
   Matrix2T uv_cov;
-  intrinsics.denormalizePoint(track.xy, uv);
+  if (!intrinsics.denormalizePoint(track.xy, uv)) {
+    return;
+  }
 
   const Matrix2T focal = intrinsics.getFocal().asDiagonal();
 
@@ -98,7 +100,9 @@ void LineIfExists(cv::InputOutputArray img, TrackId track_id, const Vector2T& or
 
   if (target != target_points.end()) {
     Vector2T uvTo;
-    target_cam.denormalizePoint(target->xy, uvTo);
+    if (!target_cam.denormalizePoint(target->xy, uvTo)) {
+      return;
+    }
     cv::line(img, {(int)origin.x(), (int)origin.y()}, {(int)uvTo.x(), (int)uvTo.y()}, color);
     if (target_primary) {
       cv::circle(img, {(int)uvTo.x(), (int)uvTo.y()}, 2, color, cv::FILLED);
@@ -279,7 +283,9 @@ static void DoStereoTrack(const std::string& edexFile, std::string outputFolder,
           DrawCovariance(drawings[cam], intrinsics, track, rgb);
         }
         Vector2T uv;
-        intrinsics.denormalizePoint(track.xy, uv);
+        if (!intrinsics.denormalizePoint(track.xy, uv)) {
+          continue;
+        }
         if (frameState == sof::FrameState::Key) {
           if (is_primary[cam]) {
             cv::circle(drawings[cam], {(int)uv.x(), (int)uv.y()}, 2, rgb, cv::FILLED);

--- a/tools/undistort/main.cpp
+++ b/tools/undistort/main.cpp
@@ -50,8 +50,12 @@ void Undistort(const camera::ICameraModel& input_model, const camera::ICameraMod
     for (int x = 0; x < output.cols; ++x) {
       Vector2T dst(x, y);
       Vector2T interim, src;
-      output_model.normalizePoint(dst, interim);
-      input_model.denormalizePoint(interim, src);
+      if (!output_model.normalizePoint(dst, interim) || !input_model.denormalizePoint(interim, src)) {
+        // Unmapped pixel — point the map outside the source so remap fills it from the border.
+        map_x.at<float>(y, x) = -1.f;
+        map_y.at<float>(y, x) = -1.f;
+        continue;
+      }
       map_x.at<float>(y, x) = src.x();
       map_y.at<float>(y, x) = src.y();
     }


### PR DESCRIPTION
normalizePoint / denormalizePoint leave their out parameter untouched when they fail, and ~15 call sites ignored the result while passing a default-constructed (i.e. uninitialized) Eigen vector. A failed conversion therefore fed indeterminate values — NaN among them — into RANSAC sample sequences, observation info matrices, GPU track positions and drawing code.

Mark both conversions [[nodiscard]] so this cannot recur, and handle the failure at every call site by dropping the point. ObservationInfoUVToXY now returns bool as well: it samples a numeric jacobian around uv, so a sample can fall outside the model even when uv itself is valid, and that sample silently skewed the resulting covariance.

This closes the ignored-failure route only. NaN can still enter through denormalizePoint itself, whose validity tests are `>` comparisons and so are false for NaN.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid camera-coordinate conversions across tracking, matching, visualization, and undistortion workflows.
  * Prevented invalid points, observations, covariance data, and correspondences from being processed or displayed.
  * Added safer handling for unmapped pixels during image undistortion.
  * Improved multicamera tracking by discarding invalid primary and secondary observations instead of using stale or incomplete data.
  * Improved reliability by reporting conversion failures and ensuring unsuccessful results are not used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->