### PR TITLE
[fix] Reject non-finite camera calibration at the API

### DIFF
--- a/libs/cuvslam/cuvslam2.cpp
+++ b/libs/cuvslam/cuvslam2.cpp
@@ -973,6 +973,9 @@ public:
     std::string message;
     TracePrintIf(!CheckCudaCompatibility(message), "[WARNING] %s\n", message.c_str());
 
+    // Slam can be constructed on its own, so it cannot rely on Odometry having vetted the rig
+    CheckCameras(rig);
+
     SetTrackerRigAndIntrinsics(cameras_models_, rig_, rig.cameras);
 
     slam::AsyncSlamOptions options;

--- a/libs/cuvslam/cuvslam2.cpp
+++ b/libs/cuvslam/cuvslam2.cpp
@@ -148,9 +148,16 @@ void CreateCameraModel(const Camera& camera, std::unique_ptr<camera::ICameraMode
   Vector2T focal{camera.focal[0], camera.focal[1]};
   Vector2T principal{camera.principal[0], camera.principal[1]};
 
-  THROW_INVALID_ARG_IF(principal[0] < 0.0 || principal[1] < 0.0, "Principal point coords must be >= 0.0");
-  THROW_INVALID_ARG_IF(focal[0] <= 0.0 || focal[1] <= 0.0, "Focal length must be > 0.0");
+  // the finiteness tests are separate: a NaN passes `<` and `<=` just as happily as a valid number
+  THROW_INVALID_ARG_IF(!principal.allFinite() || principal[0] < 0.0 || principal[1] < 0.0,
+                       "Principal point coords must be finite and >= 0.0");
+  THROW_INVALID_ARG_IF(!focal.allFinite() || focal[0] <= 0.0 || focal[1] <= 0.0,
+                       "Focal length must be finite and > 0.0");
   THROW_INVALID_ARG_IF(resolution[0] <= 0 || resolution[1] <= 0, "Image width/height must be > 0");
+
+  const auto& distortion = camera.distortion.parameters;
+  THROW_INVALID_ARG_IF(std::any_of(distortion.begin(), distortion.end(), [](float p) { return !std::isfinite(p); }),
+                       "Distortion parameters must be finite");
 
   camera_model = camera::CreateCameraModel(resolution, focal, principal, camera.distortion.model,
                                            camera.distortion.parameters.data(), camera.distortion.parameters.size());
@@ -176,9 +183,15 @@ void SetTrackerRigAndIntrinsics(std::vector<std::unique_ptr<camera::ICameraModel
 void CheckCameras(const cuvslam::Rig& rig) {
   THROW_INVALID_ARG_IF(rig.cameras.empty(), "No cameras in a rig");
   THROW_INVALID_ARG_IF(rig.cameras.size() > camera::Rig::kMaxCameras, "Number of cameras limit exceeded");
+  const auto is_finite = [](float v) { return std::isfinite(v); };
   for (const auto& cam : rig.cameras) {
     THROW_INVALID_ARG_IF(cam.size[0] != rig.cameras[0].size[0] || cam.size[1] != rig.cameras[0].size[1],
                          "All cameras resolutions must be the same");
+    // everything derived from the extrinsics inherits a NaN: rays, epipolar curves, frustum overlap
+    const auto& pose = cam.rig_from_camera;
+    THROW_INVALID_ARG_IF(!std::all_of(pose.rotation.begin(), pose.rotation.end(), is_finite) ||
+                             !std::all_of(pose.translation.begin(), pose.translation.end(), is_finite),
+                         "Camera rig_from_camera must be finite");
   }
   // Check that no two cameras have identical poses
   for (size_t i = 0; i < rig.cameras.size(); i++) {
@@ -341,7 +354,7 @@ void CheckMultisensorDepths(const Odometry::ImageSet& depths, const std::vector<
     const auto& resolution = cameras_models[depths[i].camera_index]->getResolution();
     THROW_INVALID_ARG_IF(depths[i].width != resolution[0] || depths[i].height != resolution[1],
                          "Multisensor depth image dimensions do not match camera resolution");
-    const int32_t cam_id = static_cast<int32_t>(depths[i].camera_index);
+    const auto cam_id = static_cast<int32_t>(depths[i].camera_index);
     THROW_INVALID_ARG_IF(
         std::find(expected_depth_cam_ids.begin(), expected_depth_cam_ids.end(), cam_id) == expected_depth_cam_ids.end(),
         "Multisensor depth image for camera " + std::to_string(cam_id) +
@@ -360,7 +373,7 @@ void CheckMultisensorDepths(const Odometry::ImageSet& depths, const std::vector<
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void SetVerbosity(int verbosity) {
-  constexpr const Trace::Verbosity max_allowed =
+  constexpr Trace::Verbosity max_allowed =
 #if defined(NDEBUG)
       Trace::Verbosity::Message;
 #else
@@ -666,7 +679,7 @@ PoseEstimate Odometry::Track(const ImageSet& images, const ImageSet& masks, cons
   Metas& image_metas = impl->image_metas;
   sof::Images& cuvslam_images_ptrs = impl->curr_image_ptrs;
 
-  const size_t num_cameras = static_cast<size_t>(impl->rig.num_cameras);
+  const auto num_cameras = static_cast<size_t>(impl->rig.num_cameras);
   image_sources.assign(num_cameras, {});
   masks_sources.assign(num_cameras, {});
   depth_sources.assign(num_cameras, {});

--- a/libs/cuvslam/test/tracker_test.cpp
+++ b/libs/cuvslam/test/tracker_test.cpp
@@ -16,6 +16,8 @@
 
 #include <cstdint>
 #include <limits>
+#include <stdexcept>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -50,6 +52,19 @@ Rig MakeStereoRig() {
   rig.cameras.push_back(camera);
   rig.cameras[1].rig_from_camera.translation = {kBaseline, 0.f, 0.f};
   return rig;
+}
+
+/// Checks that the rig is rejected as invalid, with a message naming the field that is at fault.
+testing::AssertionResult RejectedWith(const Rig& rig, std::string_view field) {
+  try {
+    Tracker{rig};
+  } catch (const std::invalid_argument& e) {
+    if (std::string_view{e.what()}.find(field) != std::string_view::npos) {
+      return testing::AssertionSuccess();
+    }
+    return testing::AssertionFailure() << "rejected with \"" << e.what() << "\", which does not name " << field;
+  }
+  return testing::AssertionFailure() << "rig was accepted";
 }
 
 /// Run the bundler and SLAM in the calling thread so the tests do not depend on background workers.
@@ -115,23 +130,27 @@ TEST_F(TrackerTest, RejectsNonFiniteCalibration) {
   constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
 
   // a non-finite calibration makes every projection NaN, and the range tests on the way in are all
-  // `<` or `<=`, which a NaN passes
+  // `<` or `<=`, which a NaN passes. Each rig must be turned away by the check for its own field,
+  // not by some unrelated one further down.
   Rig bad_focal{rig};
   bad_focal.cameras[0].focal = {kNan, kFocal};
-  EXPECT_THROW(Tracker{bad_focal}, std::invalid_argument);
+  EXPECT_TRUE(RejectedWith(bad_focal, "Focal length"));
 
   Rig bad_principal{rig};
   bad_principal.cameras[0].principal = {kWidth / 2.f, kNan};
-  EXPECT_THROW(Tracker{bad_principal}, std::invalid_argument);
+  EXPECT_TRUE(RejectedWith(bad_principal, "Principal point"));
 
   Rig bad_distortion{rig};
   bad_distortion.cameras[0].distortion.model = cuvslam::Distortion::Model::Fisheye;
   bad_distortion.cameras[0].distortion.parameters = {0.f, kNan, 0.f, 0.f};
-  EXPECT_THROW(Tracker{bad_distortion}, std::invalid_argument);
+  EXPECT_TRUE(RejectedWith(bad_distortion, "Distortion parameters"));
 
   Rig bad_pose{rig};
   bad_pose.cameras[1].rig_from_camera.translation = {kNan, 0.f, 0.f};
-  EXPECT_THROW(Tracker{bad_pose}, std::invalid_argument);
+  EXPECT_TRUE(RejectedWith(bad_pose, "rig_from_camera"));
+
+  // Slam is constructible on its own, so it has to reject the rig without Odometry's help
+  EXPECT_THROW(Slam(bad_pose, {0}), std::invalid_argument);
 }
 
 TEST_F(TrackerTest, TrackReturnsSlamPoseWhenEnabled) {

--- a/libs/cuvslam/test/tracker_test.cpp
+++ b/libs/cuvslam/test/tracker_test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -108,6 +109,29 @@ TEST_F(TrackerTest, GtAlignModeRequiresManualDispatch) {
   cfg.slam.gt_align_mode = true;
 
   EXPECT_THROW(Tracker(rig, cfg.odometry, &cfg.slam), std::invalid_argument);
+}
+
+TEST_F(TrackerTest, RejectsNonFiniteCalibration) {
+  constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+
+  // a non-finite calibration makes every projection NaN, and the range tests on the way in are all
+  // `<` or `<=`, which a NaN passes
+  Rig bad_focal{rig};
+  bad_focal.cameras[0].focal = {kNan, kFocal};
+  EXPECT_THROW(Tracker{bad_focal}, std::invalid_argument);
+
+  Rig bad_principal{rig};
+  bad_principal.cameras[0].principal = {kWidth / 2.f, kNan};
+  EXPECT_THROW(Tracker{bad_principal}, std::invalid_argument);
+
+  Rig bad_distortion{rig};
+  bad_distortion.cameras[0].distortion.model = cuvslam::Distortion::Model::Fisheye;
+  bad_distortion.cameras[0].distortion.parameters = {0.f, kNan, 0.f, 0.f};
+  EXPECT_THROW(Tracker{bad_distortion}, std::invalid_argument);
+
+  Rig bad_pose{rig};
+  bad_pose.cameras[1].rig_from_camera.translation = {kNan, 0.f, 0.f};
+  EXPECT_THROW(Tracker{bad_pose}, std::invalid_argument);
 }
 
 TEST_F(TrackerTest, TrackReturnsSlamPoseWhenEnabled) {


### PR DESCRIPTION
The intrinsics checks in CreateCameraModel are all `<` or `<=` comparisons, and every comparison with NaN is false, so a NaN focal length or principal point passed straight through. It then lands in the calibration matrix, where it turns every projection into a NaN pixel that no downstream bounds test can filter - those are range comparisons too, so they fail open in exactly the same way. A non-finite distortion coefficient does the same through distort(), and a non-finite rig_from_camera poisons everything derived from the extrinsics: rays, epipolar curves, frustum overlap.

Test each of them for finiteness here, next to the IMU checks that already do this. The public API is the only place untrusted calibration enters, so one check per field covers every consumer, and the user gets a message naming the field instead of a NaN surfacing much later as a silently dropped track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject invalid camera calibration values, including non-finite focal lengths, principal points, distortion parameters, and rig translations.
  * Tracker and SLAM setup now report invalid calibration data with clear, field-specific errors instead of proceeding with unusable values.
  * SLAM setup now rejects camera rigs with mismatched camera resolutions.

* **Tests**
  * Added coverage confirming invalid calibration inputs, rig translations, and mismatched camera resolutions are rejected during tracker and SLAM creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->