### PR TITLE
 [fix] Add and unify the MINIMUM_HITHER depth guards

### DIFF
--- a/libs/epipolar/camera_selection.h
+++ b/libs/epipolar/camera_selection.h
@@ -33,6 +33,10 @@ namespace FrustumProperties {
 const float MINIMUM_HITHER = 0.1f;
 }  // namespace FrustumProperties
 
+/// True when a camera-local depth clears the near plane. Prefer this over a hand-written
+/// comparison so every guard treats the boundary the same way.
+inline bool IsDepthInFront(float z) { return z > FrustumProperties::MINIMUM_HITHER; }
+
 enum class TriangulationState { None, Triangulated, AlmostParallel };
 
 /* TODO: review OptimalTriangulation limits
@@ -113,7 +117,7 @@ public:
 using Ray3T = Ray3<float>;
 
 inline bool IsPointInFrontInLocalSpace(const Vector3T& point, const Isometry3T& toLocalSpace) {
-  return (toLocalSpace * point).z() > FrustumProperties::MINIMUM_HITHER;
+  return IsDepthInFront((toLocalSpace * point).z());
 }
 
 inline bool IntersectRaysInReferenceSpace(const Isometry3T& transform, const Vector3T& direction1,
@@ -235,8 +239,7 @@ inline bool OptimalTriangulation(const Isometry3T& transform, const Vector2T& x1
   //(void)atInfinity;
   // assert((loc3d / scaleFactor).norm() < atInfinity / scaleFactor);
 
-  ts = (loc3d.z() > FrustumProperties::MINIMUM_HITHER &&
-        (transform.inverse() * loc3d).z() > FrustumProperties::MINIMUM_HITHER && loc3d.norm() > epsilon())
+  ts = (IsDepthInFront(loc3d.z()) && IsPointInFrontInLocalSpace(loc3d, transform.inverse()) && loc3d.norm() > epsilon())
            ? ((IsVectorsParallel(x1m, rotation * x2m, parallelMeasure)) ? TriangulationState::AlmostParallel
                                                                         : TriangulationState::Triangulated)
            : TriangulationState::None;

--- a/libs/epipolar/test/camera_selection_test.cpp
+++ b/libs/epipolar/test/camera_selection_test.cpp
@@ -184,4 +184,25 @@ TEST_F(CameraSelectionTest, CountPointsInFrontOfCameras_MixedPointsInFrontAndBeh
   EXPECT_EQ(expectedCount, actualCount);
 }
 
+TEST(NearPlaneGuard, IsDepthInFront_TreatsTheBoundaryAsTooClose) {
+  const float hither = cuvslam::epipolar::FrustumProperties::MINIMUM_HITHER;
+
+  EXPECT_TRUE(cuvslam::epipolar::IsDepthInFront(hither * 2.0f));
+  EXPECT_TRUE(cuvslam::epipolar::IsDepthInFront(hither * 1.01f));
+
+  // A point sitting exactly on the near plane counts as too close, not as visible.
+  EXPECT_FALSE(cuvslam::epipolar::IsDepthInFront(hither));
+  EXPECT_FALSE(cuvslam::epipolar::IsDepthInFront(hither * 0.99f));
+  EXPECT_FALSE(cuvslam::epipolar::IsDepthInFront(0.0f));
+  EXPECT_FALSE(cuvslam::epipolar::IsDepthInFront(-hither));
+}
+
+TEST(NearPlaneGuard, IsPointInFrontInLocalSpace_SharesTheSameBoundary) {
+  const float hither = cuvslam::epipolar::FrustumProperties::MINIMUM_HITHER;
+  const Isometry3T identity = Isometry3T::Identity();
+
+  EXPECT_TRUE(cuvslam::epipolar::IsPointInFrontInLocalSpace(Vector3T(0.0f, 0.0f, hither * 2.0f), identity));
+  EXPECT_FALSE(cuvslam::epipolar::IsPointInFrontInLocalSpace(Vector3T(0.0f, 0.0f, hither), identity));
+}
+
 }  // namespace test::epipolar

--- a/libs/pipelines/sba_mono_wrapper.cpp
+++ b/libs/pipelines/sba_mono_wrapper.cpp
@@ -17,7 +17,7 @@
 
 #include "pipelines/internal/mono/sba_mono_wrapper.h"
 
-#include "epipolar/camera_selection.h"  // for HEATER
+#include "epipolar/camera_selection.h"  // for IsDepthInFront
 #include "sba/mono_sba_solver.h"
 
 namespace cuvslam::pipelines {
@@ -33,7 +33,7 @@ static bool calcTrackResidualInFrame(const Isometry3T& inverse_camera, const sto
   const Vector3T v3 = inverse_camera * outTrack.getLocation3D();
   const float z = v3.z();
 
-  if (z < epipolar::FrustumProperties::MINIMUM_HITHER) {
+  if (!epipolar::IsDepthInFront(z)) {
     return false;
   }
   const Vector2T proj = v3.head(2) / z;

--- a/libs/sba/mono_sba_solver.cpp
+++ b/libs/sba/mono_sba_solver.cpp
@@ -346,9 +346,6 @@ bool MonoSBASolver::getFailed() const { return failed_; }
 Matrix6T MonoSBASolver::getCovariance() const { return covariance_; }
 
 void MonoSBASolver::filterHitherPoints() {
-  // Also see FrustumProperties::MINIMUM_HITHER (+Z forward, OpenCV)
-  static const float hither = cuvslam::epipolar::FrustumProperties::MINIMUM_HITHER;
-
   for (Track& track : tracks_) {
     if (track.skip) {
       continue;
@@ -357,7 +354,7 @@ void MonoSBASolver::filterHitherPoints() {
     for (size_t idxFrame : track.idxFrames) {
       const Vector3T loc3dInCamCoord = frames_[idxFrame].a.transform() * track.b;
 
-      if (loc3dInCamCoord.z() < hither) {
+      if (!cuvslam::epipolar::IsDepthInFront(loc3dInCamCoord.z())) {
         track.skip = true;
         break;
       }

--- a/libs/slam/slam/loop_closure_solver/lcs_simple.cpp
+++ b/libs/slam/slam/loop_closure_solver/lcs_simple.cpp
@@ -213,7 +213,7 @@ void LoopClosureSolverSimple::SelectLandmarksCandidates(const LoopClosureTask& t
       const Vector3T point_guess = camera_from_world_guess * xyz;
       // same near plane the triangulator and the visibility test use — a landmark nearer than this
       // was never triangulated, and a failed lookup comes back as the origin, at zero depth
-      if (point_guess.z() <= epipolar::FrustumProperties::MINIMUM_HITHER) {
+      if (!epipolar::IsDepthInFront(point_guess.z())) {
         continue;
       }
       const Vector2T uv_guess_norm = point_guess.topRows(2) / point_guess.z();

--- a/libs/slam/slam/loop_closure_solver/lcs_simple.cpp
+++ b/libs/slam/slam/loop_closure_solver/lcs_simple.cpp
@@ -20,6 +20,7 @@
 
 #include "camera/observation.h"
 #include "camera/rig.h"
+#include "epipolar/camera_selection.h"
 #include "epipolar/fundamental_ransac.h"
 
 #include "slam/slam/loop_closure_solver/iloop_closure_solver.h"
@@ -210,6 +211,11 @@ void LoopClosureSolverSimple::SelectLandmarksCandidates(const LoopClosureTask& t
     for (LandmarkId id : lsi_candidate_ids) {
       const Vector3T xyz = landmarks_spatial_index.GetLandmarkOrStagedCoords(id, *task.pose_graph_hypothesis);
       const Vector3T point_guess = camera_from_world_guess * xyz;
+      // same near plane the triangulator and the visibility test use — a landmark nearer than this
+      // was never triangulated, and a failed lookup comes back as the origin, at zero depth
+      if (point_guess.z() <= epipolar::FrustumProperties::MINIMUM_HITHER) {
+        continue;
+      }
       const Vector2T uv_guess_norm = point_guess.topRows(2) / point_guess.z();
       Vector2T uv_guess;
       if (!intrinsics.denormalizePoint(uv_guess_norm, uv_guess)) {


### PR DESCRIPTION
Summary

Two related fixes to the near plane depth guard, plus a shared predicate so the guard cannot drift apart again. One site was missing the guard entirely; two others disagreed with everyone else about what happens exactly on the boundary.

The bugs

Loop closure never checked depth at all. LoopClosureSolverSimple::SelectLandmarksCandidates projected every candidate with no depth test, so a landmark behind the camera produced a mirrored pixel that could land inside the image and waste a descriptor match. Worse, GetLandmarkOrStagedCoords returns the origin when the landmark is missing, and projecting that divides by a depth of exactly zero whenever the guess pose sits at the world origin.

Two guards disagreed about the boundary. Every other site treats a point as visible only when z > MINIMUM_HITHER, but calcTrackResidualInFrame and MonoSBASolver::filterHitherPoints skipped only on strictly-less, so they accepted points sitting exactly on the near plane that the rest of the pipeline rejects. filterHitherPoints compared against a function-local alias of the constant, which is why it does not turn up in a search for MINIMUM_HITHER.

The change

New predicate in libs/epipolar/camera_selection.h, directly under the constant so anyone who finds MINIMUM_HITHER finds the guard that uses it:

inline bool IsDepthInFront(float z) { return z > FrustumProperties::MINIMUM_HITHER; }


The predicate takes a depth rather than a point plus a transform, because every call site has already applied the transform and needs the transformed point immediately afterwards for the projection. Routing them through IsPointInFrontInLocalSpace would redo the multiply in per-frame code.

Incidental cleanups that fall out of this: filterHitherPoints loses its static const float hither alias and its now-redundant "Also see" comment, and the stale // for HEATER include comment in sba_mono_wrapper.cpp becomes // for IsDepthInFront.

Tests

Two cases in libs/epipolar/test/camera_selection_test.cpp pin the near plane boundary itself as not in front, which is the exact property that had drifted, and check that IsPointInFrontInLocalSpace shares that boundary.

Out of scope

About a dozen depth guards still compare against a bare zero rather than the near plane (lsi_grid.cpp, depth_point_map.cpp, epipolar_curves.cpp, feature_predictor.cpp, winsorizer.cpp, frustum_intersection_graph.cpp, the two visualizers, imu_sba_fixed_vel.cpp). Converting those is a behavior change for each caller and belongs in its own MR.