### PR TITLE
[fix] Reject a non-finite camera pose on every rig path

### DIFF
--- a/libs/cuvslam/cuvslam2.cpp
+++ b/libs/cuvslam/cuvslam2.cpp
@@ -152,6 +152,13 @@ void CreateCameraModel(const Camera& camera, std::unique_ptr<camera::ICameraMode
   THROW_INVALID_ARG_IF(focal[0] <= 0.0 || focal[1] <= 0.0, "Focal length must be > 0.0");
   THROW_INVALID_ARG_IF(resolution[0] <= 0 || resolution[1] <= 0, "Image width/height must be > 0");
 
+  // everything built from the extrinsics inherits a NaN: rays, epipolar curves, frustum overlap
+  const auto is_finite = [](float v) { return std::isfinite(v); };
+  const auto& pose = camera.rig_from_camera;
+  THROW_INVALID_ARG_IF(!std::all_of(pose.rotation.begin(), pose.rotation.end(), is_finite) ||
+                           !std::all_of(pose.translation.begin(), pose.translation.end(), is_finite),
+                       "Camera rig_from_camera must be finite");
+
   camera_model = camera::CreateCameraModel(resolution, focal, principal, camera.distortion.model,
                                            camera.distortion.parameters.data(), camera.distortion.parameters.size());
   THROW_INVALID_ARG_IF(!camera_model, "Failed to create camera model with " +

--- a/libs/cuvslam/test/tracker_test.cpp
+++ b/libs/cuvslam/test/tracker_test.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <cstdint>
+#include <limits>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -108,6 +109,13 @@ TEST_F(TrackerTest, GtAlignModeRequiresManualDispatch) {
   cfg.slam.gt_align_mode = true;
 
   EXPECT_THROW(Tracker(rig, cfg.odometry, &cfg.slam), std::invalid_argument);
+}
+
+TEST_F(TrackerTest, RejectsNonFiniteCameraPose) {
+  Rig bad_pose{rig};
+  bad_pose.cameras[1].rig_from_camera.translation = {std::numeric_limits<float>::quiet_NaN(), 0.f, 0.f};
+
+  EXPECT_THROW(Tracker{bad_pose}, std::invalid_argument);
 }
 
 TEST_F(TrackerTest, TrackReturnsSlamPoseWhenEnabled) {


### PR DESCRIPTION
CheckCameras never tested rig_from_camera for finiteness, so a NaN camera pose reached the internal rig untouched. Everything built from the extrinsics then inherits it - camera rays, epipolar curves, frustum overlap - and no bounds test downstream catches it, because those are range comparisons and every comparison with NaN is false.

Test it in CreateCameraModel, next to the intrinsics checks. That function is the per-camera validation funnel SetTrackerRigAndIntrinsics calls, which is what both entry points use: Odometry::Odometry and the Slam implementation. Putting the test in CheckCameras instead would leave a standalone Slam unguarded, since that path never calls it.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject camera configurations containing invalid, non-finite position or rotation values.
  * Improved error handling for invalid stereo camera poses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->