### PR TITLE
[infra] Add TartanAir provisioning image

### DIFF
--- a/.github/workflows/provision-datasets.yml
+++ b/.github/workflows/provision-datasets.yml
@@ -57,6 +57,16 @@ jobs:
           DOCKER_BUILDKIT=1 docker build -f scripts/Dockerfile.ci . --network host --tag cuvslam-ci:local \
             --secret id=aws_cli_public_key,src="$keyfile"
 
+      - name: Verify TartanGround provisioning architecture
+        if: github.event.inputs.dataset == 'tartan'
+        env:
+          RUNNER_ARCH: ${{ runner.arch }}
+        run: |
+          if [ "$RUNNER_ARCH" != X64 ]; then
+            echo "TartanGround provisioning requires an x86_64 runner; got $RUNNER_ARCH." >&2
+            exit 1
+          fi
+
       - name: Build TartanGround provisioning image
         if: github.event.inputs.dataset == 'tartan'
         run: |

--- a/.github/workflows/provision-datasets.yml
+++ b/.github/workflows/provision-datasets.yml
@@ -57,8 +57,16 @@ jobs:
           DOCKER_BUILDKIT=1 docker build -f scripts/Dockerfile.ci . --network host --tag cuvslam-ci:local \
             --secret id=aws_cli_public_key,src="$keyfile"
 
+      - name: Build TartanGround provisioning image
+        if: github.event.inputs.dataset == 'tartan'
+        run: |
+          DOCKER_BUILDKIT=1 docker build -f scripts/Dockerfile.dataset-provision . --network host \
+            --build-arg BASE_IMAGE=cuvslam-ci:local \
+            --tag cuvslam-dataset-provision:local
+
       - name: Seed S3 dataset tarball
         env:
+          DATASET: ${{ github.event.inputs.dataset }}
           FORCE_DOWNLOAD: ${{ github.event.inputs.force_download }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           AWS_ACCESS_KEY_ID: ${{ github.event.inputs.dry_run != 'true' && secrets.AWS_S3_ACCESS_KEY_ID || '' }}
@@ -66,6 +74,10 @@ jobs:
         run: |
           host_work="$RUNNER_TEMP/provision-work-${GITHUB_RUN_ID}"
           container_work=/tmp/cuvslam-provision
+          provision_image=cuvslam-ci:local
+          if [ "$DATASET" = tartan ]; then
+            provision_image=cuvslam-dataset-provision:local
+          fi
           mkdir -p "$host_work"
           docker run --rm --network host \
             -e FORCE_DOWNLOAD -e DRY_RUN -e AWS_DEFAULT_REGION -e S3_DATASETS_BUCKET \
@@ -74,4 +86,4 @@ jobs:
             -v "$(pwd):/cuvslam:ro" \
             -v "$host_work:$container_work" \
             -w /cuvslam \
-            cuvslam-ci:local ./scripts/provision_dataset.sh "${{ github.event.inputs.dataset }}"
+            "$provision_image" ./scripts/provision_dataset.sh "$DATASET"

--- a/scripts/Dockerfile.dataset-provision
+++ b/scripts/Dockerfile.dataset-provision
@@ -17,3 +17,5 @@ RUN pip install --no-cache-dir \
     tartanair==1.4.0 \
     numpy==2.2.3 \
     scipy==1.15.3
+
+RUN python3 -c "import cv2; import tartanair"

--- a/scripts/Dockerfile.dataset-provision
+++ b/scripts/Dockerfile.dataset-provision
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE=cuvslam-ci:local
+FROM ${BASE_IMAGE}
+
+# TartanGround provisioning uses the official TartanAir toolbox. Keep this
+# dependency out of the shared CI image because it brings a large, x86-only
+# scientific/CUDA dependency stack that other datasets do not need.
+RUN pip install --no-cache-dir \
+    tartanair==1.4.0 \
+    numpy==2.2.3 \
+    scipy==1.15.3

--- a/scripts/Dockerfile.dataset-provision
+++ b/scripts/Dockerfile.dataset-provision
@@ -6,6 +6,13 @@ FROM ${BASE_IMAGE}
 # TartanGround provisioning uses the official TartanAir toolbox. Keep this
 # dependency out of the shared CI image because it brings a large, x86-only
 # scientific/CUDA dependency stack that other datasets do not need.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgl1 \
+    libglib2.0-0t64 \
+    libxcb1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir \
     tartanair==1.4.0 \
     numpy==2.2.3 \

--- a/scripts/check-isolated-ruleset-change.sh
+++ b/scripts/check-isolated-ruleset-change.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-PROTECTED_REGEX='^(\.github/rulesets/.*|\.github/CODEOWNERS|\.github/workflows/(pr-verify|nightly|provision-datasets)\.yml|scripts/Dockerfile\.ci|\.pre-commit-config\.yaml|scripts/check-isolated-ruleset-change\.sh)$'
+PROTECTED_REGEX='^(\.github/rulesets/.*|\.github/CODEOWNERS|\.github/workflows/(pr-verify|nightly|provision-datasets)\.yml|scripts/Dockerfile\.(ci|dataset-provision)|\.pre-commit-config\.yaml|scripts/check-isolated-ruleset-change\.sh)$'
 
 # Base resolution order: explicit ISOLATION_BASE_REF, then CI's GITHUB_BASE_REF,
 # then the optional positional fallback base (passed by the local pre-push hook).


### PR DESCRIPTION
Keep the heavy x86-only TartanAir dependency stack out of the shared CI tools image while making TartanGround provisioning self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for provisioning the TartanGround dataset with a dedicated container image.
  - Dataset selection now automatically chooses the appropriate provisioning environment.
  - Added the required dependencies and compatibility checks for reliable TartanGround dataset setup.
  - Provisioning now validates the required x86_64 environment for TartanGround.

- **Chores**
  - Updated protected-file checks to include the new dataset provisioning configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->