### PR TITLE
[infra] stream and profile evaluation dataset staging

### DIFF
--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -26,23 +26,19 @@ if command -v aws >/dev/null 2>&1; then
   fi
 fi
 
-# One greppable line per staged dataset, with the same fields regardless of how
-# the dataset was fetched so logs from different staging strategies can be
-# compared field by field. Streaming reports "-" for the per-phase figures
-# because transfer and extraction overlap and are no longer separable.
+# One greppable line per staged dataset. The step duration is already visible in
+# the Actions UI, but that covers every dataset at once, so report the per-dataset
+# figures the UI cannot show: payload size, file count, and the throughput that
+# makes two runs comparable at a glance.
 report_staging_profile() {
-  local name="$1" bytes="$2" total_seconds="$3" download_seconds="$4" extract_seconds="$5" file_count="$6"
-  local mib="unknown" download_rate="-" total_rate="unknown"
+  local name="$1" bytes="$2" total_seconds="$3" file_count="$4"
+  local mib="unknown" total_rate="unknown"
   if [[ "$bytes" =~ ^[0-9]+$ ]]; then
     mib=$((bytes / 1048576))
     [ "$total_seconds" -gt 0 ] && total_rate=$((mib / total_seconds))
-    if [[ "$download_seconds" =~ ^[0-9]+$ ]] && [ "$download_seconds" -gt 0 ]; then
-      download_rate=$((mib / download_seconds))
-    fi
   fi
-  echo "staging profile: dataset=$name mib=$mib download_s=$download_seconds" \
-    "extract_s=$extract_seconds total_s=$total_seconds files=$file_count" \
-    "download_mib_s=$download_rate total_mib_s=$total_rate"
+  echo "staging profile: dataset=$name mib=$mib total_s=$total_seconds" \
+    "files=$file_count total_mib_s=$total_rate"
 }
 
 stage_one() {
@@ -117,7 +113,7 @@ stage_one() {
   local file_count
   file_count="$(find "$dest" -type f ! -name '.s3_etag' | wc -l)"
   echo "  staged $file_count files under $dest"
-  report_staging_profile "$name" "$remote_bytes" "$stream_seconds" - - "$file_count"
+  report_staging_profile "$name" "$remote_bytes" "$stream_seconds" "$file_count"
 }
 
 for name in "${EVAL_DATASET_NAMES[@]}"; do

--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -15,6 +15,8 @@ S3_KEY_PREFIX="${_s3_path#*/}"
 
 mkdir -p "$LOCAL_DATASETS_DIR"
 
+echo "Dataset cache root: $LOCAL_DATASETS_DIR (RUNNER_LOCAL_DATASETS_ROOT=$RUNNER_LOCAL_DATASETS_ROOT)"
+
 have_aws=false
 if command -v aws >/dev/null 2>&1; then
   if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
@@ -23,6 +25,23 @@ if command -v aws >/dev/null 2>&1; then
     have_aws=true
   fi
 fi
+
+# One greppable line per staged dataset. Download and extract are reported
+# separately because they scale with different things and need different fixes:
+# bandwidth for the transfer, file count for the extraction.
+report_staging_profile() {
+  local name="$1" bytes="$2" download_seconds="$3" extract_seconds="$4" file_count="$5"
+  local total_seconds=$((download_seconds + extract_seconds))
+  local mib="unknown" download_rate="unknown" total_rate="unknown"
+  if [[ "$bytes" =~ ^[0-9]+$ ]]; then
+    mib=$((bytes / 1048576))
+    [ "$download_seconds" -gt 0 ] && download_rate=$((mib / download_seconds))
+    [ "$total_seconds" -gt 0 ] && total_rate=$((mib / total_seconds))
+  fi
+  echo "staging profile: dataset=$name mib=$mib download_s=$download_seconds" \
+    "extract_s=$extract_seconds total_s=$total_seconds files=$file_count" \
+    "download_mib_s=$download_rate total_mib_s=$total_rate"
+}
 
 stage_one() {
   local name="$1"
@@ -34,14 +53,27 @@ stage_one() {
   tmp_tar="$(mktemp "${TMPDIR:-/tmp}/cuvslam-${name}.XXXXXX.tar")"
 
   remote_etag=""
+  remote_bytes=""
   if $have_aws; then
-    remote_etag="$(aws s3api head-object --bucket "$S3_BUCKET" --key "$s3_key" --query ETag --output text 2>/dev/null || true)"
+    # ETag and size come from one request so the staging profile can report
+    # throughput without stat(2) on a local copy.
+    head_output="$(aws s3api head-object --bucket "$S3_BUCKET" --key "$s3_key" \
+      --query '[ETag,ContentLength]' --output text 2>/dev/null || true)"
+    if [ -n "$head_output" ]; then
+      remote_etag="$(printf '%s' "$head_output" | cut -f1)"
+      remote_bytes="$(printf '%s' "$head_output" | cut -f2)"
+    fi
   fi
 
   cache_has_files=false
   if [ -d "$dest" ] && [ -n "$(find "$dest" -type f ! -name '.s3_etag' -print -quit 2>/dev/null)" ]; then
     cache_has_files=true
   fi
+
+  cached_etag="none"
+  [ -f "$etag_file" ] && cached_etag="$(cat "$etag_file")"
+  echo "Cache check $name: have_aws=$have_aws cache_has_files=$cache_has_files" \
+    "force_restage=$FORCE_RESTAGE remote_etag=${remote_etag:-none} cached_etag=$cached_etag"
 
   if [ "$FORCE_RESTAGE" != "true" ] && $cache_has_files; then
     if ! $have_aws; then
@@ -60,15 +92,23 @@ stage_one() {
   fi
 
   echo "Staging $name from $s3_uri -> $dest"
+  local download_start=$SECONDS
   aws s3 cp "$s3_uri" "$tmp_tar" --no-progress
+  local download_seconds=$((SECONDS - download_start))
+
   rm -rf "$dest"
   mkdir -p "$dest"
+  local extract_start=$SECONDS
   tar -xf "$tmp_tar" -C "$dest"
+  local extract_seconds=$((SECONDS - extract_start))
   rm -f "$tmp_tar"
   if [ -n "$remote_etag" ]; then
     echo "$remote_etag" > "$etag_file"
   fi
-  echo "  staged $(find "$dest" -type f ! -name '.s3_etag' | wc -l) files under $dest"
+  local file_count
+  file_count="$(find "$dest" -type f ! -name '.s3_etag' | wc -l)"
+  echo "  staged $file_count files under $dest"
+  report_staging_profile "$name" "$remote_bytes" "$download_seconds" "$extract_seconds" "$file_count"
 }
 
 for name in "${EVAL_DATASET_NAMES[@]}"; do

--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -26,17 +26,19 @@ if command -v aws >/dev/null 2>&1; then
   fi
 fi
 
-# One greppable line per staged dataset. Download and extract are reported
-# separately because they scale with different things and need different fixes:
-# bandwidth for the transfer, file count for the extraction.
+# One greppable line per staged dataset, with the same fields regardless of how
+# the dataset was fetched so logs from different staging strategies can be
+# compared field by field. Streaming reports "-" for the per-phase figures
+# because transfer and extraction overlap and are no longer separable.
 report_staging_profile() {
-  local name="$1" bytes="$2" download_seconds="$3" extract_seconds="$4" file_count="$5"
-  local total_seconds=$((download_seconds + extract_seconds))
-  local mib="unknown" download_rate="unknown" total_rate="unknown"
+  local name="$1" bytes="$2" total_seconds="$3" download_seconds="$4" extract_seconds="$5" file_count="$6"
+  local mib="unknown" download_rate="-" total_rate="unknown"
   if [[ "$bytes" =~ ^[0-9]+$ ]]; then
     mib=$((bytes / 1048576))
-    [ "$download_seconds" -gt 0 ] && download_rate=$((mib / download_seconds))
     [ "$total_seconds" -gt 0 ] && total_rate=$((mib / total_seconds))
+    if [[ "$download_seconds" =~ ^[0-9]+$ ]] && [ "$download_seconds" -gt 0 ]; then
+      download_rate=$((mib / download_seconds))
+    fi
   fi
   echo "staging profile: dataset=$name mib=$mib download_s=$download_seconds" \
     "extract_s=$extract_seconds total_s=$total_seconds files=$file_count" \
@@ -49,8 +51,6 @@ stage_one() {
   local s3_uri="s3://${S3_BUCKET}/${s3_key}"
   local dest="$LOCAL_DATASETS_DIR/$name"
   local etag_file="$dest/.s3_etag"
-  local tmp_tar
-  tmp_tar="$(mktemp "${TMPDIR:-/tmp}/cuvslam-${name}.XXXXXX.tar")"
 
   remote_etag=""
   remote_bytes=""
@@ -92,23 +92,32 @@ stage_one() {
   fi
 
   echo "Staging $name from $s3_uri -> $dest"
-  local download_start=$SECONDS
-  aws s3 cp "$s3_uri" "$tmp_tar" --no-progress
-  local download_seconds=$((SECONDS - download_start))
+  # Extract as the object arrives: peak disk is one expanded dataset instead of
+  # the archive plus its expansion, which matters most for the largest corpora.
+  # Extraction lands in a sibling directory and is swapped in only on success,
+  # so a failed transfer leaves any existing cache intact.
+  local staging_dir="${dest}.partial"
+  rm -rf "$staging_dir"
+  mkdir -p "$staging_dir"
+  local stream_start=$SECONDS
+  # pipefail is set at the top of this script, so a failed download or a
+  # truncated archive fails the pipeline rather than yielding a partial dataset.
+  if ! aws s3 cp "$s3_uri" - --no-progress | tar -xf - -C "$staging_dir"; then
+    rm -rf "$staging_dir"
+    echo "Error: staging $name failed; existing cache at $dest is unchanged." >&2
+    exit 1
+  fi
+  local stream_seconds=$((SECONDS - stream_start))
 
   rm -rf "$dest"
-  mkdir -p "$dest"
-  local extract_start=$SECONDS
-  tar -xf "$tmp_tar" -C "$dest"
-  local extract_seconds=$((SECONDS - extract_start))
-  rm -f "$tmp_tar"
+  mv "$staging_dir" "$dest"
   if [ -n "$remote_etag" ]; then
     echo "$remote_etag" > "$etag_file"
   fi
   local file_count
   file_count="$(find "$dest" -type f ! -name '.s3_etag' | wc -l)"
   echo "  staged $file_count files under $dest"
-  report_staging_profile "$name" "$remote_bytes" "$download_seconds" "$extract_seconds" "$file_count"
+  report_staging_profile "$name" "$remote_bytes" "$stream_seconds" - - "$file_count"
 }
 
 for name in "${EVAL_DATASET_NAMES[@]}"; do


### PR DESCRIPTION
## Summary

Stage evaluation datasets by piping the S3 object straight into `tar` instead of
buffering the whole archive in `$TMPDIR`, and log a per-dataset staging profile.

- **Faster:** step drops from ~6.3 min to ~3.5 min (199–210 MiB/s vs 105–112).
- **Less disk:** peak is one expanded dataset instead of archive + expansion.
  (E.g. will save ~276 GB transient on M3ED once the full suite is enabled.)
- **Non-destructive:** extraction lands in a sibling `.partial` directory swapped
  in on success. `main` runs `rm -rf "$dest"` before `tar`, so a corrupt archive
  currently leaves no dataset at all.
- **Observable:** one greppable line per dataset with payload size, file count,
  and throughput. Cache-decision inputs are logged too.

Measured: KITTI 22142 MiB / 87141 files, EuRoC 18274 MiB / 53128 files. Extraction runs ~1000 files/s and was
42% of the old path, so file count is the next lever if staging needs more work.

Touches `scripts/stage_eval_datasets.sh` only.

## Test plan

- [x] `bash -n scripts/stage_eval_datasets.sh`
- [x] `pre-commit run --files scripts/stage_eval_datasets.sh`
- [x] Offline runs against a stubbed `aws`: cold stage, ETag cache hit,
      `FORCE_RESTAGE=true`, and a corrupt archive (exit 1, existing cache intact,
      no `.partial` left behind)
- [x] Baseline nightly: https://github.com/nvidia-isaac/cuVSLAM/actions/runs/33076744641
- [x] Streaming nightly: https://github.com/nvidia-isaac/cuVSLAM/actions/runs/33076820163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Dataset staging now reports cache location, archive size, file count, processing duration, and throughput.
  - Cache diagnostics include remote and locally cached version identifiers for easier troubleshooting.
  - Downloads are handled more safely, preserving the existing cached dataset if staging fails.
  - Successful staging operations replace datasets cleanly and provide clearer completion metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->