### PR TITLE
[clean] Remove the DECREASE_RANSAC_AREA build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,6 @@ option(USE_CUDA "Use CUDA Toolkit" ON)
 option(ENFORCE_GPU "Disable the usage of pure CPU version of cuVSLAM" ON)
 option(CUVSLAM_LOG_ENABLE "Enable root cuvslam::Log." OFF)
 option(SOF_USE_SMALLER_NCC "Use 3-pixel area for NCC. Possible it is useful for fisheye. By default, NCC uses 5 pixels." OFF)
-option(DECREASE_RANSAC_AREA "Do not use 10% tracks for RANSAC near the image border. Possible useful for fisheye. The Default is to use all tracks." OFF)
 option(CUVSLAM_BUILD_SHARED_LIB "Build shared library version of cuVSLAM" TRUE)
 option(USE_RERUN "Use Rerun for visualization" OFF)
 

--- a/cmake/cuVSLAMUtils.cmake
+++ b/cmake/cuVSLAMUtils.cmake
@@ -48,7 +48,6 @@ macro(setup_cuvslam_settings)
         $<$<BOOL:${USE_SLAM_OUTPUT}>:USE_SLAM_OUTPUT>
         $<$<BOOL:${USE_LMDB}>:USE_LMDB>
         $<$<BOOL:${SOF_USE_SMALLER_NCC}>:SOF_USE_SMALLER_NCC>
-        $<$<BOOL:${DECREASE_RANSAC_AREA}>:DECREASE_RANSAC_AREA>
         $<$<BOOL:${USE_NVTX}>:USE_NVTX>
         $<$<BOOL:${USE_CUDA}>:USE_CUDA>
         $<$<BOOL:${ENFORCE_GPU}>:ENFORCE_GPU>

--- a/libs/sof/sof_mono_cpu.cpp
+++ b/libs/sof/sof_mono_cpu.cpp
@@ -223,14 +223,6 @@ void MonoSOFCPU::collapseTracks(const ImageContextPtr &image, TracksVector &trac
 
 void MonoSOFCPU::ransacFilter(const camera::ICameraModel &intrinsics, const TracksVector &last_keyframe_tracks,
                               TracksVector &tracks) {
-#ifdef DECREASE_RANSAC_AREA
-  const Vector2T furthestLocation((float)currentImage().cols() * 0.5f, (float)currentImage().rows() * 0.5f);
-  float radius = furthestLocation.norm();
-  const float boundaryPercentage = 0.9f;
-  radius *= boundaryPercentage;
-  const Vector2T lensPrincipal = intrinsics.getPrincipal();
-  Vector2TPairVector sampleSequenceForRansac;
-#endif
   auto lastIt = last_keyframe_tracks.cbegin();
   auto lastEnd = last_keyframe_tracks.cend();
   Vector2TPairVector sampleSequence;
@@ -253,17 +245,6 @@ void MonoSOFCPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
       continue;
     }
     sampleSequence.emplace_back(v1, v2);
-
-#ifdef DECREASE_RANSAC_AREA
-    const Vector2T trackRadius = track.position() - lensPrincipal;
-
-    if (trackRadius.norm() > radius) {
-      continue;
-    }
-
-    sampleSequenceForRansac.emplace_back(intrinsics.normalizePoint(lastIt->position()),
-                                         intrinsics.normalizePoint(track.position()));
-#endif
   }
 
   const float threshold = RANSAC_ACCURACY_THRESHOLD;
@@ -271,12 +252,7 @@ void MonoSOFCPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
   Matrix3T essential;
   math::Ransac<epipolar::Fundamental> fr;
   fr.setOptions(math::Ransac<epipolar::Fundamental>::Epipolar, threshold, 0.002f);
-#ifdef DECREASE_RANSAC_AREA
-  if (!fr(essential, sampleSequenceForRansac.begin(), sampleSequenceForRansac.end()))
-#else
-  if (!fr(essential, sampleSequence.begin(), sampleSequence.end()))
-#endif
-  {
+  if (!fr(essential, sampleSequence.begin(), sampleSequence.end())) {
     return;
   }
 

--- a/libs/sof/sof_mono_gpu.cpp
+++ b/libs/sof/sof_mono_gpu.cpp
@@ -286,14 +286,6 @@ void MonoSOFGPU::collapseTracks(ImageContextPtr image, TracksVector &tracks) {
 
 void MonoSOFGPU::ransacFilter(const camera::ICameraModel &intrinsics, const TracksVector &last_keyframe_tracks,
                               TracksVector &tracks) {
-#ifdef DECREASE_RANSAC_AREA
-  const Vector2T furthestLocation((float)currentImage().cols() * 0.5f, (float)currentImage().rows() * 0.5f);
-  float radius = furthestLocation.norm();
-  const float boundaryPercentage = 0.9f;
-  radius *= boundaryPercentage;
-  const Vector2T lensPrincipal = intrinsics.getPrincipal();
-  Vector2TPairVector sampleSequenceForRansac;
-#endif
   auto lastIt = last_keyframe_tracks.cbegin();
   auto lastEnd = last_keyframe_tracks.cend();
   Vector2TPairVector sampleSequence;
@@ -316,17 +308,6 @@ void MonoSOFGPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
       continue;
     }
     sampleSequence.emplace_back(v1, v2);
-
-#ifdef DECREASE_RANSAC_AREA
-    const Vector2T trackRadius = track.position() - lensPrincipal;
-
-    if (trackRadius.norm() > radius) {
-      continue;
-    }
-
-    sampleSequenceForRansac.emplace_back(intrinsics.normalizePoint(lastIt->position()),
-                                         intrinsics.normalizePoint(track.position()));
-#endif
   }
 
   const float threshold = RANSAC_ACCURACY_THRESHOLD;
@@ -334,12 +315,7 @@ void MonoSOFGPU::ransacFilter(const camera::ICameraModel &intrinsics, const Trac
   Matrix3T essential;
   math::Ransac<epipolar::Fundamental> fr;
   fr.setOptions(math::Ransac<epipolar::Fundamental>::Epipolar, threshold, 0.002f);
-#ifdef DECREASE_RANSAC_AREA
-  if (!fr(essential, sampleSequenceForRansac.begin(), sampleSequenceForRansac.end()))
-#else
-  if (!fr(essential, sampleSequence.begin(), sampleSequence.end()))
-#endif
-  {
+  if (!fr(essential, sampleSequence.begin(), sampleSequence.end())) {
     return;
   }
 


### PR DESCRIPTION
The option defaulted to OFF and dropped tracks outside 90% of the image radius before running RANSAC in MonoSOFCPU/MonoSOFGPU::ransacFilter(). Nobody turned it on, and the guarded branch could not even build: it called the one-argument normalizePoint() overload while the live path uses the two-argument bool-returning form.

Removes the option, its compile definition, and the three #ifdef blocks in each of sof_mono_cpu.cpp and sof_mono_gpu.cpp. The default build path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monocular tracking robustness by allowing RANSAC filtering to use correspondences across the full image area.
  * Standardized RANSAC behavior across CPU and GPU processing paths.
* **Build Configuration**
  * Removed the option for restricting RANSAC processing to a reduced image area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->