### PR TITLE
[fix] derive dataset S3 keys in one place

### DIFF
--- a/scripts/datasets_config.sh
+++ b/scripts/datasets_config.sh
@@ -27,18 +27,30 @@ dataset_upload_subdir() {
   esac
 }
 
-s3_tarball_uri() {
+s3_dataset_bucket() {
+  local _s3_path="${S3_DATASETS_BUCKET#s3://}"
+  echo "${_s3_path%%/*}"
+}
+
+# Object key for one dataset tarball. S3_DATASETS_BUCKET may name a bucket root,
+# in which case there is no prefix at all, and it may carry a trailing slash,
+# which must not survive into the key: S3 treats "prefix//name.tar" as a
+# different object than "prefix/name.tar".
+s3_dataset_key() {
   local name="$1"
   local _s3_path="${S3_DATASETS_BUCKET#s3://}"
-  local bucket="${_s3_path%%/*}"
   local prefix=""
   case "$_s3_path" in
     */*) prefix="${_s3_path#*/}" ;;
   esac
   while [ "${prefix%/}" != "$prefix" ]; do prefix="${prefix%/}"; done
   if [ -n "$prefix" ]; then
-    echo "s3://${bucket}/${prefix}/${name}.tar"
+    echo "${prefix}/${name}.tar"
   else
-    echo "s3://${bucket}/${name}.tar"
+    echo "${name}.tar"
   fi
+}
+
+s3_tarball_uri() {
+  echo "s3://$(s3_dataset_bucket)/$(s3_dataset_key "$1")"
 }

--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -9,9 +9,7 @@ RUNNER_LOCAL_DATASETS_ROOT="${RUNNER_LOCAL_DATASETS_ROOT:-${HOME:-/tmp}/.cache/c
 LOCAL_DATASETS_DIR="$RUNNER_LOCAL_DATASETS_ROOT/datasets/vslam"
 FORCE_RESTAGE="${FORCE_RESTAGE:-false}"
 
-_s3_path="${S3_DATASETS_BUCKET#s3://}"
-S3_BUCKET="${_s3_path%%/*}"
-S3_KEY_PREFIX="${_s3_path#*/}"
+S3_BUCKET="$(s3_dataset_bucket)"
 
 mkdir -p "$LOCAL_DATASETS_DIR"
 
@@ -26,8 +24,9 @@ fi
 
 stage_one() {
   local name="$1"
-  local s3_key="${S3_KEY_PREFIX}/${name}.tar"
-  local s3_uri="s3://${S3_BUCKET}/${s3_key}"
+  local s3_key s3_uri
+  s3_key="$(s3_dataset_key "$name")"
+  s3_uri="$(s3_tarball_uri "$name")"
   local dest="$LOCAL_DATASETS_DIR/$name"
   local etag_file="$dest/.s3_etag"
   local tmp_tar


### PR DESCRIPTION
Staging re-derived the object key inline with
S3_KEY_PREFIX="${_s3_path#*/}", which is wrong in two ways that provisioning already handles.

With no key prefix configured, the pattern does not match and the expansion returns the bucket name unchanged, so s3://bucket asks for s3://bucket/bucket/<name>.tar. With a configured trailing slash the key becomes prefix//<name>.tar, and S3 treats that as a different object than prefix/<name>.tar. Either way staging looks for something provisioning never wrote. Only the currently configured shape, a prefix with no trailing slash, happens to agree.

Move the derivation into s3_dataset_bucket and s3_dataset_key next to the existing guard logic, express s3_tarball_uri in terms of them, and have staging call them instead of re-deriving. Provisioning and staging can no longer disagree.

No change for the configuration in use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset archive location handling for more consistent cloud storage paths.
  * Preserved dataset prefixes and trailing-slash behavior when constructing archive locations.
  * Updated evaluation dataset staging to use consistent dataset path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->