### PR TITLE
[feat] add TUM RGB-D conversion for the 15 evaluated sequences

### DIFF
--- a/tools/python_tools/README.md
+++ b/tools/python_tools/README.md
@@ -74,7 +74,7 @@ Reinstall the binding after rebuilding `libcuvslam.so`.
 | `prepare_kitti` | Download KITTI odometry archives, convert them to cuVSLAM format, and generate KITTI reporter configs. |
 | `prepare_euroc` | Download and convert all 11 official EuRoC MAV sequences, or an explicit subset, to portable EDEX and reporter configs. |
 | `prepare_tartan` | Download TartanGround data and convert TartanGround stereo pairs or compatible TartanAir-layout sequences to EDEX. |
-| `prepare_tum` | Download and lay out the TUM RGB-D `freiburg3_long_office_household` dataset. |
+| `prepare_tum` | Download and convert the 15 evaluated TUM RGB-D freiburg3 sequences, or an explicit subset, to portable EDEX and a reporter config. |
 | `cuvslam_tracker` | Run one EDEX sequence or supported video input through cuVSLAM. |
 | `cuvslam_reporter` | Run one dataset config and generate report outputs. |
 | `cuvslam_validator` | Run multiple reporter configs, combine results, and apply validation checks. |
@@ -185,12 +185,44 @@ data.
 
 Use `--variant multicamera` for EDEX conversion from the 12-camera TartanGround image variant. Both TartanGround variants also download metadata, including `pose_lcam_*` and `pose_rcam_*` files. The multicamera variant converts each complete stereo orientation, for example `P2000_front`, `P2000_left`, and `P2000_right`. The `multisensor` variant is intended for the RGB-D/IMU example data and can be downloaded with `--download-only`.
 
-`prepare_tum` runs `cuvslam_tools.dataset_preparation.tum.prepare`. It downloads and lays out the TUM RGB-D `freiburg3_long_office_household` dataset and copies the bundled rig calibration into the sequence folder.
+`prepare_tum` runs `cuvslam_tools.dataset_preparation.tum.prepare`. It downloads the 15 evaluated TUM RGB-D
+freiburg3 sequence archives and converts them to portable EDEX with a reporter config.
 
 ```bash
 prepare_tum \
     --raw-dir /path/to/datasets/tum/raw \
     --output-dir /path/to/datasets/converted
+
+# One sequence, for a quick check (roughly 1.5 GB of source data)
+prepare_tum \
+    --raw-dir /path/to/datasets/tum/raw \
+    --output-dir /path/to/datasets/converted \
+    --sequences rgbd_dataset_freiburg3_long_office_household
+```
+
+The prepared root is `/path/to/datasets/converted/tum`. It contains `tum-rgbd_slam.cfg` and
+`dataset_metadata.json`. Every sequence contains `stereo.edex`, `frame_metadata.jsonl`, camera-aligned `gt.txt`,
+colour PNGs under `00/`, and depth PNGs under `01/`.
+
+Colour and depth frames are associated within 1 ms, which pairs the two views of a single Kinect capture and
+rejects pairs stitched across neighbouring captures. Ground truth is interpolated onto the associated frame times
+(linear translation, slerp rotation) and written relative to the first frame. Frames outside the ground-truth time
+span are dropped so every frame has a pose.
+
+Depth is copied from the source unchanged: 16-bit PNG in TUM units, declared in the EDEX as
+`depth_scale_factor: 5000`. All 15 sequences come from the freiburg3 camera series, whose published pinhole
+intrinsics carry no distortion, so one calibration covers the selection.
+
+Run the combined RGB-D ODOM+SLAM report with:
+
+```bash
+cuvslam_reporter \
+    --test_config /path/to/datasets/converted/tum/tum-rgbd_slam.cfg \
+    --datasets_root /path/to/datasets/converted \
+    --output_root /tmp/cuvslam-tum-reports \
+    --odometry_mode rgbd \
+    --async_sba false \
+    --use_segments
 ```
 
 All dataset preparation commands support `--force-download` and `--download-only`, default to `./datasets/<dataset>/raw`

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/rgbd.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/rgbd.py
@@ -1,0 +1,484 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+"""Shared primitives for converting RGB-D datasets to the cuVSLAM reporter layout.
+
+TUM RGB-D and ICL-NUIM both ship independently timestamped colour and depth
+streams plus a sparse ground-truth trajectory, and both need the same four
+steps: associate colour to depth, interpolate ground truth onto the associated
+frame times, emit ``frame_metadata.jsonl`` and ``gt.txt``, and emit a
+``stereo.edex`` rig description.
+
+Timestamps are parsed with :class:`decimal.Decimal` and scaled to integer
+nanoseconds, so a text timestamp maps to exactly one integer regardless of
+binary floating-point rounding.
+
+The SE(3) and quaternion helpers duplicate private equivalents in
+``euroc/convert_euroc.py``. Folding EuRoC onto these is a separate cleanup;
+changing the EuRoC converter here would put an unrelated dataset's output at
+risk.
+"""
+
+import bisect
+import json
+import math
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Dict, List, Optional, Sequence, Tuple
+
+NANOSECONDS_PER_SECOND = 1_000_000_000
+
+# Reporter reads "dataset_folder" relative to CUVSLAM_DATASETS and every other
+# path relative to the sequence directory.
+EDEX_FILE = "stereo.edex"
+GROUND_TRUTH_FILE = "gt.txt"
+FRAME_METADATA_FILE = "frame_metadata.jsonl"
+
+# Colour is camera 0. Depth shares that camera's id because it is registered to
+# the colour image; the folder names are labels only.
+COLOR_DIR = "00"
+DEPTH_DIR = "01"
+
+
+class RgbdConversionError(RuntimeError):
+    """Raised when a source RGB-D sequence cannot be converted."""
+
+
+# (timestamp_ns, relative source path)
+IndexEntry = Tuple[int, str]
+# (timestamp_ns, translation xyz, quaternion xyzw)
+TrajectoryRow = Tuple[int, List[float], List[float]]
+# (color_timestamp_ns, color_path, depth_timestamp_ns, depth_path)
+FramePair = Tuple[int, str, int, str]
+
+
+@dataclass(frozen=True)
+class PinholeCamera:
+    """Pinhole intrinsics for a colour camera with registered depth."""
+
+    focal: Tuple[float, float]
+    principal: Tuple[float, float]
+    size: Tuple[int, int]
+    # Denominator converting raw depth samples to metres. Native TUM 16-bit PNG
+    # depth uses 5000; float32 depth already in metres uses 1.
+    depth_scale_factor: float
+
+
+def _parse_timestamp_ns(text: str, source: str, line_number: int) -> int:
+    try:
+        return int(Decimal(text) * NANOSECONDS_PER_SECOND)
+    except (InvalidOperation, ValueError) as exc:
+        raise RgbdConversionError(
+            f"{source} line {line_number}: invalid timestamp {text!r}"
+        ) from exc
+
+
+def _data_lines(text: str) -> List[Tuple[int, List[str]]]:
+    rows = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        rows.append((line_number, stripped.split()))
+    return rows
+
+
+def read_timestamp_index(text: str, source: str) -> List[IndexEntry]:
+    """Parse a ``<timestamp> <relative path>`` index such as TUM's ``rgb.txt``."""
+    entries: List[IndexEntry] = []
+    previous = None
+    for line_number, columns in _data_lines(text):
+        if len(columns) != 2:
+            raise RgbdConversionError(
+                f"{source} line {line_number}: expected 2 columns, got {len(columns)}"
+            )
+        timestamp = _parse_timestamp_ns(columns[0], source, line_number)
+        if previous is not None and timestamp <= previous:
+            raise RgbdConversionError(
+                f"{source} line {line_number}: timestamps must be strictly increasing"
+            )
+        entries.append((timestamp, columns[1]))
+        previous = timestamp
+    if not entries:
+        raise RgbdConversionError(f"{source}: no entries")
+    return entries
+
+
+def _normalize_quaternion(quaternion: List[float], source: str, line_number: int) -> List[float]:
+    norm = sum(component * component for component in quaternion) ** 0.5
+    if norm <= 0.0:
+        raise RgbdConversionError(f"{source} line {line_number}: zero-length quaternion")
+    return [component / norm for component in quaternion]
+
+
+def read_tum_trajectory(text: str, source: str) -> List[TrajectoryRow]:
+    """Parse a ``<timestamp> tx ty tz qx qy qz qw`` trajectory file.
+
+    This is the TUM RGB-D ground-truth format: the pose of the colour camera's
+    optical frame in the world frame, with the same axis convention cuVSLAM uses
+    (x right, y down, z forward), so no axis permutation is applied.
+    """
+    rows: List[TrajectoryRow] = []
+    previous = None
+    for line_number, columns in _data_lines(text):
+        if len(columns) != 8:
+            raise RgbdConversionError(
+                f"{source} line {line_number}: expected 8 columns, got {len(columns)}"
+            )
+        timestamp = _parse_timestamp_ns(columns[0], source, line_number)
+        try:
+            values = [float(column) for column in columns[1:]]
+        except ValueError as exc:
+            raise RgbdConversionError(
+                f"{source} line {line_number}: invalid numeric value"
+            ) from exc
+        if previous is not None and timestamp <= previous:
+            raise RgbdConversionError(
+                f"{source} line {line_number}: timestamps must be strictly increasing"
+            )
+        rows.append(
+            (timestamp, values[0:3], _normalize_quaternion(values[3:7], source, line_number))
+        )
+        previous = timestamp
+    if not rows:
+        raise RgbdConversionError(f"{source}: no ground-truth poses")
+    return rows
+
+
+def associate(
+    color: Sequence[IndexEntry],
+    depth: Sequence[IndexEntry],
+    max_difference_ns: int,
+) -> List[FramePair]:
+    """Match colour to depth frames, closest pair first, each frame used once.
+
+    This reproduces the selection in TUM's published ``associate.py``: every
+    candidate pair within the tolerance is considered, the smallest time
+    difference wins, and both frames are then consumed. Ties break on timestamp,
+    so the result does not depend on iteration order.
+    """
+    if max_difference_ns <= 0:
+        raise RgbdConversionError("association tolerance must be positive")
+
+    # Both indices are sorted, so the window of depth frames within tolerance of
+    # a colour frame only ever moves forward. Enumerating the full cross product
+    # instead would be several million comparisons on a single TUM sequence.
+    candidates = []
+    window_start = 0
+    for color_ts, _ in color:
+        while window_start < len(depth) and depth[window_start][0] <= color_ts - max_difference_ns:
+            window_start += 1
+        index = window_start
+        while index < len(depth) and depth[index][0] < color_ts + max_difference_ns:
+            candidates.append((abs(color_ts - depth[index][0]), color_ts, depth[index][0]))
+            index += 1
+    candidates.sort()
+    color_paths = dict(color)
+    depth_paths = dict(depth)
+    used_color = set()
+    used_depth = set()
+    matched: List[FramePair] = []
+    for _, color_ts, depth_ts in candidates:
+        if color_ts in used_color or depth_ts in used_depth:
+            continue
+        used_color.add(color_ts)
+        used_depth.add(depth_ts)
+        matched.append((color_ts, color_paths[color_ts], depth_ts, depth_paths[depth_ts]))
+    matched.sort()
+    if not matched:
+        raise RgbdConversionError("no colour frame is within the association tolerance of a depth frame")
+    return matched
+
+
+def restrict_to_trajectory(pairs: Sequence[FramePair], trajectory: Sequence[TrajectoryRow]) -> List[FramePair]:
+    """Drop frames outside the ground-truth time span so every frame has a pose."""
+    first = trajectory[0][0]
+    last = trajectory[-1][0]
+    inside = [pair for pair in pairs if first <= pair[0] <= last]
+    if not inside:
+        raise RgbdConversionError("no associated frame falls inside the ground-truth time span")
+    return inside
+
+
+def quaternion_to_matrix(quaternion: Sequence[float]) -> List[List[float]]:
+    """Convert an xyzw quaternion to a row-major 3x3 rotation matrix."""
+    x, y, z, w = quaternion
+    return [
+        [1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)],
+        [2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)],
+        [2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)],
+    ]
+
+
+def _slerp(first: Sequence[float], second: Sequence[float], weight: float) -> List[float]:
+    dot = sum(a * b for a, b in zip(first, second))
+    target = list(second)
+    if dot < 0.0:
+        # A quaternion and its negation are the same rotation; take the short arc.
+        target = [-component for component in second]
+        dot = -dot
+    if dot > 0.9995:
+        # Nearly parallel: slerp is numerically unstable here and lerp is within
+        # float noise of it.
+        blended = [a + weight * (b - a) for a, b in zip(first, target)]
+    else:
+        sine = (1.0 - dot * dot) ** 0.5
+        angle = math.atan2(sine, dot)
+        first_weight = math.sin((1.0 - weight) * angle) / sine
+        second_weight = math.sin(weight * angle) / sine
+        blended = [a * first_weight + b * second_weight for a, b in zip(first, target)]
+    norm = sum(component * component for component in blended) ** 0.5
+    return [component / norm for component in blended]
+
+
+def interpolate_pose(
+    trajectory: Sequence[TrajectoryRow], timestamps: Sequence[int], timestamp: int
+) -> Tuple[List[List[float]], List[float]]:
+    """Interpolate the trajectory at one frame time.
+
+    Translation is interpolated linearly and rotation with slerp. ``timestamps``
+    is the precomputed list of trajectory times, kept as an argument so callers
+    can build it once per sequence.
+    """
+    if timestamp <= timestamps[0]:
+        row = trajectory[0]
+        return quaternion_to_matrix(row[2]), list(row[1])
+    if timestamp >= timestamps[-1]:
+        row = trajectory[-1]
+        return quaternion_to_matrix(row[2]), list(row[1])
+
+    index = bisect.bisect_left(timestamps, timestamp)
+    if timestamps[index] == timestamp:
+        row = trajectory[index]
+        return quaternion_to_matrix(row[2]), list(row[1])
+
+    before = trajectory[index - 1]
+    after = trajectory[index]
+    span = after[0] - before[0]
+    weight = (timestamp - before[0]) / span
+    translation = [a + weight * (b - a) for a, b in zip(before[1], after[1])]
+    rotation = _slerp(before[2], after[2], weight)
+    return quaternion_to_matrix(rotation), translation
+
+
+def invert_transform(
+    rotation: Sequence[Sequence[float]], translation: Sequence[float]
+) -> Tuple[List[List[float]], List[float]]:
+    """Invert a rigid transform given as a rotation matrix and translation."""
+    transposed = [[rotation[column][row] for column in range(3)] for row in range(3)]
+    inverse_translation = [
+        -sum(transposed[row][column] * translation[column] for column in range(3)) for row in range(3)
+    ]
+    return transposed, inverse_translation
+
+
+def compose_transforms(
+    first_rotation: Sequence[Sequence[float]],
+    first_translation: Sequence[float],
+    second_rotation: Sequence[Sequence[float]],
+    second_translation: Sequence[float],
+) -> Tuple[List[List[float]], List[float]]:
+    """Return the composition of two rigid transforms, first applied last."""
+    rotation = [
+        [sum(first_rotation[row][inner] * second_rotation[inner][column] for inner in range(3)) for column in range(3)]
+        for row in range(3)
+    ]
+    translation = [
+        sum(first_rotation[row][inner] * second_translation[inner] for inner in range(3)) + first_translation[row]
+        for row in range(3)
+    ]
+    return rotation, translation
+
+
+def relative_ground_truth_lines(
+    trajectory: Sequence[TrajectoryRow], pairs: Sequence[FramePair]
+) -> List[str]:
+    """Render ``gt.txt``: one row-major 3x4 pose per frame, relative to frame 0.
+
+    The reporter compares odometry against a trajectory that starts at the
+    origin, so the first row is exactly the identity and later rows are
+    ``pose(frame 0)^-1 * pose(frame i)``.
+    """
+    timestamps = [row[0] for row in trajectory]
+    first_rotation, first_translation = interpolate_pose(trajectory, timestamps, pairs[0][0])
+    inverse_rotation, inverse_translation = invert_transform(first_rotation, first_translation)
+    lines = [
+        "1.000000e+00 0.000000e+00 0.000000e+00 0.000000e+00 "
+        "0.000000e+00 1.000000e+00 0.000000e+00 0.000000e+00 "
+        "0.000000e+00 0.000000e+00 1.000000e+00 0.000000e+00"
+    ]
+    for pair in pairs[1:]:
+        rotation, translation = interpolate_pose(trajectory, timestamps, pair[0])
+        relative_rotation, relative_translation = compose_transforms(
+            inverse_rotation, inverse_translation, rotation, translation
+        )
+        values = (
+            relative_rotation[0]
+            + [relative_translation[0]]
+            + relative_rotation[1]
+            + [relative_translation[1]]
+            + relative_rotation[2]
+            + [relative_translation[2]]
+        )
+        lines.append(" ".join(f"{value:.6e}" for value in values))
+    return lines
+
+
+def frame_metadata_lines(
+    pairs: Sequence[FramePair], color_names: Sequence[str], depth_names: Sequence[str]
+) -> List[str]:
+    """Render ``frame_metadata.jsonl``, one JSON object per associated frame."""
+    if not (len(pairs) == len(color_names) == len(depth_names)):
+        raise RgbdConversionError("frame metadata inputs have mismatched lengths")
+    lines = []
+    for frame_index, (pair, color_name, depth_name) in enumerate(zip(pairs, color_names, depth_names)):
+        color_timestamp, _, depth_timestamp, _ = pair
+        lines.append(
+            json.dumps(
+                {
+                    "frame_id": frame_index,
+                    "cams": [
+                        {
+                            "id": 0,
+                            "filename": f"{COLOR_DIR}/{color_name}",
+                            "timestamp": color_timestamp,
+                        }
+                    ],
+                    "depth": [
+                        {
+                            "id": 0,
+                            "filename": f"{DEPTH_DIR}/{depth_name}",
+                            "timestamp": depth_timestamp,
+                        }
+                    ],
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+    return lines
+
+
+def edex_document(
+    camera: PinholeCamera,
+    frame_count: int,
+    first_color_name: str,
+    first_depth_name: str,
+) -> List[Dict[str, object]]:
+    """Build the two-section EDEX document for a single RGB-D camera.
+
+    ``frame_metadata`` drives replay, so ``sequence`` and ``depth_sequence`` are
+    templates the reader only consults when frame metadata is absent. They are
+    still written with real filenames because other tooling reads them, and the
+    depth entry's extension is what tells the reader whether depth samples are
+    millimetres in a PNG or metres in a ``.npy``.
+    """
+    if frame_count <= 0:
+        raise RgbdConversionError("cannot describe an empty sequence")
+    return [
+        {
+            "version": "0.9",
+            "frame_start": 0,
+            "frame_end": frame_count - 1,
+            "cameras": [
+                {
+                    "transform": [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                    ],
+                    "intrinsics": {
+                        "distortion_model": "pinhole",
+                        "distortion_params": [],
+                        "focal": [camera.focal[0], camera.focal[1]],
+                        "principal": [camera.principal[0], camera.principal[1]],
+                        "size": [camera.size[0], camera.size[1]],
+                    },
+                    "depth_id": 0,
+                    "depth_scale_factor": camera.depth_scale_factor,
+                }
+            ],
+        },
+        {
+            "frame_metadata": FRAME_METADATA_FILE,
+            "points2d": {},
+            "points3d": {},
+            "rig_positions": {},
+            "sequence": [[f"{COLOR_DIR}/{first_color_name}"]],
+            "depth_sequence": [[f"{DEPTH_DIR}/{first_depth_name}"]],
+        },
+    ]
+
+
+def reporter_sequence_entry(
+    sequence_folder: str,
+    sequence_title: str,
+    use_slam: bool,
+    gt_file: Optional[str] = GROUND_TRUTH_FILE,
+) -> List[Tuple[str, object]]:
+    """Build one reporter ``sequence_cfgs`` entry as ordered key/value pairs.
+
+    ``edex_file`` and ``gt_file_path`` are always written even though the
+    reporter defaults the former to ``stereo.edex``: omitting ``gt_file_path``
+    makes the reporter run the sequence with no ground truth at all, which is how
+    the legacy TUM config silently produced ungated numbers.
+    """
+    fields: List[Tuple[str, object]] = [
+        ("enable", True),
+        ("sequence_folder", sequence_folder),
+        ("edex_file", EDEX_FILE),
+        ("precompute_2d_tracks", False),
+        ("precompute_key_frames", False),
+        ("use_gt_scale", False),
+        ("sequence_title", sequence_title),
+    ]
+    if gt_file:
+        fields.append(("gt_file_path", gt_file))
+    if use_slam:
+        fields.append(("use_slam", True))
+    return fields
+
+
+def format_reporter_config(
+    entries: Sequence[Sequence[Tuple[str, object]]],
+    dataset_folder: str,
+    segment_lengths: Sequence[float],
+) -> str:
+    """Render a reporter config file.
+
+    Emitted as text rather than through ``json.dumps`` so the layout matches the
+    KITTI and EuRoC converters, which the reporter fixtures were written against.
+    ``dataset_folder`` must equal ``<dataset id>/``; the registry validates that.
+    """
+    if not entries:
+        raise RgbdConversionError("cannot write a reporter config with no sequences")
+    lines = [
+        "{",
+        '    "version": "0.1",',
+        '    "write_cache": false,',
+        '    "use_cuda": false,',
+        f'    "dataset_folder": {json.dumps(dataset_folder)},',
+        '    "use_icp_scaling": false,',
+        f'    "segment_lengths": {json.dumps(list(segment_lengths))},',
+        '    "sequence_cfgs": [',
+    ]
+    for entry_index, fields in enumerate(entries):
+        lines.append("        {")
+        for field_index, (key, value) in enumerate(fields):
+            comma = "," if field_index + 1 < len(fields) else ""
+            lines.append(f'            "{key}": {json.dumps(value)}{comma}')
+        comma = "," if entry_index + 1 < len(entries) else ""
+        lines.append(f"        }}{comma}")
+    lines.extend(["  ]", "}", ""])
+    return "\n".join(lines)

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/rgbd.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/rgbd.py
@@ -77,11 +77,18 @@ class PinholeCamera:
 
 def _parse_timestamp_ns(text: str, source: str, line_number: int) -> int:
     try:
-        return int(Decimal(text) * NANOSECONDS_PER_SECOND)
+        seconds = Decimal(text)
     except (InvalidOperation, ValueError) as exc:
         raise RgbdConversionError(
             f"{source} line {line_number}: invalid timestamp {text!r}"
         ) from exc
+    # Decimal accepts "inf" and "nan"; converting either to an integer raises
+    # something outside this module's error contract.
+    if not seconds.is_finite():
+        raise RgbdConversionError(
+            f"{source} line {line_number}: non-finite timestamp {text!r}"
+        )
+    return int(seconds * NANOSECONDS_PER_SECOND)
 
 
 def _data_lines(text: str) -> List[Tuple[int, List[str]]]:
@@ -143,6 +150,12 @@ def read_tum_trajectory(text: str, source: str) -> List[TrajectoryRow]:
             raise RgbdConversionError(
                 f"{source} line {line_number}: invalid numeric value"
             ) from exc
+        # float() accepts "inf" and "nan". Left alone they propagate into every
+        # interpolated pose as silently wrong ground truth rather than an error.
+        if not all(math.isfinite(value) for value in values):
+            raise RgbdConversionError(
+                f"{source} line {line_number}: non-finite pose value"
+            )
         if previous is not None and timestamp <= previous:
             raise RgbdConversionError(
                 f"{source} line {line_number}: timestamps must be strictly increasing"
@@ -167,6 +180,10 @@ def associate(
     candidate pair within the tolerance is considered, the smallest time
     difference wins, and both frames are then consumed. Ties break on timestamp,
     so the result does not depend on iteration order.
+
+    Both indices must be sorted by timestamp, which
+    :func:`read_timestamp_index` guarantees. Unsorted input does not raise; the
+    sliding window below simply stops early and silently drops pairs.
     """
     if max_difference_ns <= 0:
         raise RgbdConversionError("association tolerance must be positive")

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/rgbd.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/rgbd.py
@@ -123,8 +123,12 @@ def read_timestamp_index(text: str, source: str) -> List[IndexEntry]:
 
 
 def _normalize_quaternion(quaternion: List[float], source: str, line_number: int) -> List[float]:
-    norm = sum(component * component for component in quaternion) ** 0.5
-    if norm <= 0.0:
+    # hypot rather than sum-of-squares: squaring overflows to infinity for large
+    # components, which normalizes to an all-zero quaternion and then to an
+    # identity rotation, and underflows to zero for tiny ones, which reads as a
+    # zero-length quaternion. Both are silent corruption of the ground truth.
+    norm = math.hypot(*quaternion)
+    if norm <= 0.0 or not math.isfinite(norm):
         raise RgbdConversionError(f"{source} line {line_number}: zero-length quaternion")
     return [component / norm for component in quaternion]
 
@@ -255,7 +259,7 @@ def _slerp(first: Sequence[float], second: Sequence[float], weight: float) -> Li
         first_weight = math.sin((1.0 - weight) * angle) / sine
         second_weight = math.sin(weight * angle) / sine
         blended = [a * first_weight + b * second_weight for a, b in zip(first, target)]
-    norm = sum(component * component for component in blended) ** 0.5
+    norm = math.hypot(*blended)
     return [component / norm for component in blended]
 
 

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/tum/convert_tum.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/tum/convert_tum.py
@@ -1,0 +1,333 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+"""Convert the TUM RGB-D freiburg3 sequences to the cuVSLAM reporter layout.
+
+Produces, per sequence::
+
+    <sequence>/00/000000.png          colour, copied byte for byte
+    <sequence>/01/000000.png          depth, copied byte for byte (16-bit, scale 5000)
+    <sequence>/frame_metadata.jsonl   associated colour/depth frames with timestamps
+    <sequence>/gt.txt                 3x4 pose per frame, relative to frame 0
+    <sequence>/stereo.edex            rig, intrinsics, and depth scale
+
+plus a ``dataset_metadata.json`` and the reporter configs at the dataset root.
+
+Depth is copied unchanged rather than expanded to float32 ``.npy`` as the
+retired pipeline did. The reader accepts a 16-bit PNG directly and applies
+``depth_scale_factor``, so the extra step only cost precision (it quantised to
+whole millimetres) and roughly five times the disk.
+"""
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from cuvslam_tools.dataset_preparation import rgbd
+from cuvslam_tools.dataset_preparation.rgbd import RgbdConversionError as ConversionError
+
+_SCHEMA_VERSION = 1
+_CONVERTER_VERSION = 1
+
+SOURCE_NAME = "TUM RGB-D Benchmark"
+SOURCE_URL = "https://cvg.cit.tum.de/data/datasets/rgbd-dataset"
+SOURCE_CITATION = (
+    "J. Sturm, N. Engelhard, F. Endres, W. Burgard and D. Cremers, "
+    "A Benchmark for the Evaluation of RGB-D SLAM Systems, IROS 2012"
+)
+
+# The 15 freiburg3 sequences the retired nightly evaluated, in report order.
+ALL_SEQS: Tuple[str, ...] = (
+    "rgbd_dataset_freiburg3_sitting_halfsphere",
+    "rgbd_dataset_freiburg3_nostructure_texture_far",
+    "rgbd_dataset_freiburg3_nostructure_notexture_near_withloop",
+    "rgbd_dataset_freiburg3_teddy",
+    "rgbd_dataset_freiburg3_structure_texture_far",
+    "rgbd_dataset_freiburg3_walking_halfsphere",
+    "rgbd_dataset_freiburg3_structure_notexture_far",
+    "rgbd_dataset_freiburg3_sitting_xyz",
+    "rgbd_dataset_freiburg3_cabinet",
+    "rgbd_dataset_freiburg3_nostructure_texture_near_withloop",
+    "rgbd_dataset_freiburg3_nostructure_notexture_far",
+    "rgbd_dataset_freiburg3_sitting_xyz_validation",
+    "rgbd_dataset_freiburg3_structure_texture_near",
+    "rgbd_dataset_freiburg3_long_office_household",
+    "rgbd_dataset_freiburg3_large_cabinet_validation",
+)
+
+# TUM is a full-suite corpus only: ICL-NUIM covers RGB-D in the smoke suite at
+# less than half the staging cost, so no subset config is generated here.
+
+# Published ROS defaults for the freiburg3 camera series. All 15 selected
+# sequences come from that series, so one intrinsics set covers them, and the
+# series is rectified: its distortion coefficients are all zero.
+FREIBURG3_CAMERA = rgbd.PinholeCamera(
+    focal=(535.4, 539.2),
+    principal=(320.1, 247.6),
+    size=(640, 480),
+    depth_scale_factor=5000.0,
+)
+
+# Colour and depth are two views of the same Kinect capture, so their timestamps
+# normally differ by tens of microseconds. 1 ms keeps pairs that came from one
+# capture and rejects pairs stitched across neighbouring captures, which would
+# break the pixel-to-pixel alignment RGB-D tracking assumes: relaxing this to
+# half a frame interval (20 ms) adds 43 pairs on long_office_household whose
+# colour and depth are up to 8.2 ms apart. It also matches the retired pipeline,
+# whose largest shipped colour-to-depth offset is 990 us.
+ASSOCIATION_TOLERANCE_NS = 1_000_000
+
+SEGMENT_LENGTHS: Tuple[float, ...] = (1, 2, 3, 5, 7.5, 10, 15, 20, 25, 35, 45)
+
+DATASET_ID = "tum"
+_INDEX_FILES = ("rgb.txt", "depth.txt", "groundtruth.txt")
+
+
+def archive_name(sequence: str) -> str:
+    """Return the source archive filename for one sequence."""
+    return f"{sequence}.tgz"
+
+
+def _selected_sequences(sequences: Optional[Sequence[str]]) -> List[str]:
+    if sequences is None:
+        return list(ALL_SEQS)
+    selected = list(sequences)
+    if not selected:
+        raise ConversionError("no sequences selected")
+    unknown = [sequence for sequence in selected if sequence not in ALL_SEQS]
+    if unknown:
+        raise ConversionError(
+            f"unknown sequence(s): {', '.join(sorted(unknown))}; known: {', '.join(ALL_SEQS)}"
+        )
+    duplicated = sorted({sequence for sequence in selected if selected.count(sequence) > 1})
+    if duplicated:
+        raise ConversionError(f"duplicate sequence(s): {', '.join(duplicated)}")
+    # Keep the retired report order regardless of the order requested.
+    return [sequence for sequence in ALL_SEQS if sequence in set(selected)]
+
+
+def required_archives(sequences: Optional[Sequence[str]] = None) -> List[str]:
+    """Return the source archives needed to convert the selected sequences."""
+    return [archive_name(sequence) for sequence in _selected_sequences(sequences)]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_index_text(sequence_root: Path, name: str, sequence: str) -> str:
+    path = sequence_root / name
+    if not path.is_file():
+        raise ConversionError(f"{sequence}: missing {name} in {sequence_root}")
+    return path.read_text(encoding="utf-8")
+
+
+def _copy_media(
+    sequence_root: Path,
+    sequence: str,
+    pairs: Sequence[rgbd.FramePair],
+    color_output: Path,
+    depth_output: Path,
+) -> Tuple[List[str], List[str]]:
+    color_names: List[str] = []
+    depth_names: List[str] = []
+    for frame_index, (_, color_source, _, depth_source) in enumerate(pairs):
+        name = f"{frame_index:06d}.png"
+        for source_relative, destination in (
+            (color_source, color_output / name),
+            (depth_source, depth_output / name),
+        ):
+            source = sequence_root / source_relative
+            if not source.is_file():
+                raise ConversionError(f"{sequence}: missing image {source_relative}")
+            shutil.copyfile(source, destination)
+        color_names.append(name)
+        depth_names.append(name)
+    return color_names, depth_names
+
+
+def convert_sequence(sequence_root: Path, sequence: str, output_dir: Path) -> Dict[str, object]:
+    """Convert one extracted TUM sequence and return its metadata."""
+    texts = {name: _read_index_text(sequence_root, name, sequence) for name in _INDEX_FILES}
+    color_index = rgbd.read_timestamp_index(texts["rgb.txt"], f"{sequence}/rgb.txt")
+    depth_index = rgbd.read_timestamp_index(texts["depth.txt"], f"{sequence}/depth.txt")
+    trajectory = rgbd.read_tum_trajectory(texts["groundtruth.txt"], f"{sequence}/groundtruth.txt")
+
+    associated = rgbd.associate(color_index, depth_index, ASSOCIATION_TOLERANCE_NS)
+    pairs = rgbd.restrict_to_trajectory(associated, trajectory)
+
+    sequence_dir = output_dir / sequence
+    if sequence_dir.is_symlink():
+        raise ConversionError(f"{sequence}: refusing to replace symlinked output directory")
+    if sequence_dir.exists():
+        shutil.rmtree(sequence_dir)
+    color_output = sequence_dir / rgbd.COLOR_DIR
+    depth_output = sequence_dir / rgbd.DEPTH_DIR
+    color_output.mkdir(parents=True)
+    depth_output.mkdir()
+
+    color_names, depth_names = _copy_media(sequence_root, sequence, pairs, color_output, depth_output)
+
+    (sequence_dir / rgbd.FRAME_METADATA_FILE).write_text(
+        "\n".join(rgbd.frame_metadata_lines(pairs, color_names, depth_names)) + "\n",
+        encoding="utf-8",
+    )
+    (sequence_dir / rgbd.GROUND_TRUTH_FILE).write_text(
+        "\n".join(rgbd.relative_ground_truth_lines(trajectory, pairs)) + "\n",
+        encoding="utf-8",
+    )
+    (sequence_dir / rgbd.EDEX_FILE).write_text(
+        json.dumps(
+            rgbd.edex_document(FREIBURG3_CAMERA, len(pairs), color_names[0], depth_names[0]),
+            indent=4,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "sequence": sequence,
+        "source_archive": archive_name(sequence),
+        "source_counts": {
+            "color_frames": len(color_index),
+            "depth_frames": len(depth_index),
+            "ground_truth_poses": len(trajectory),
+        },
+        "converted_counts": {
+            "frames": len(pairs),
+            "ground_truth_poses": len(pairs),
+        },
+        "association_tolerance_ns": ASSOCIATION_TOLERANCE_NS,
+        "dropped_outside_ground_truth": len(associated) - len(pairs),
+    }
+
+
+def _config_entries(sequences: Sequence[str]) -> List[List[Tuple[str, object]]]:
+    entries = []
+    for sequence in sequences:
+        # freiburg3-sitting-xyz-ODOM, matching the retired report titles.
+        title = sequence.replace("rgbd_dataset_", "").replace("_", "-")
+        for use_slam in (False, True):
+            entries.append(
+                rgbd.reporter_sequence_entry(
+                    sequence_folder=sequence,
+                    sequence_title=f"{title}-{'SLAM' if use_slam else 'ODOM'}",
+                    use_slam=use_slam,
+                )
+            )
+    return entries
+
+
+def _write_configs(output_dir: Path, sequences: Sequence[str]) -> List[str]:
+    """Write the reporter configs, returning their names.
+
+    One config, covering every converted sequence in both ODOM and SLAM modes.
+    Its name determines the KPI prefix: the collector takes everything before the
+    first hyphen, so ``tum-rgbd_slam.cfg`` yields ``TUM``.
+    """
+    configs = {f"{DATASET_ID}-rgbd_slam.cfg": _config_entries(sequences)}
+    dataset_folder = f"{DATASET_ID}/"
+    for name, entries in configs.items():
+        (output_dir / name).write_text(
+            rgbd.format_reporter_config(entries, dataset_folder, SEGMENT_LENGTHS),
+            encoding="utf-8",
+        )
+    return sorted(configs)
+
+
+def _dataset_metadata(
+    archives: List[Dict[str, str]],
+    config_names: List[str],
+    sequence_metadata: List[Dict[str, object]],
+) -> Dict[str, object]:
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "converter_version": _CONVERTER_VERSION,
+        "source": {
+            "name": SOURCE_NAME,
+            "url": SOURCE_URL,
+            "citation": SOURCE_CITATION,
+            "archives": archives,
+        },
+        "camera": {
+            "series": "freiburg3",
+            "distortion_model": "pinhole",
+            "focal": list(FREIBURG3_CAMERA.focal),
+            "principal": list(FREIBURG3_CAMERA.principal),
+            "size": list(FREIBURG3_CAMERA.size),
+            "depth_scale_factor": FREIBURG3_CAMERA.depth_scale_factor,
+            "depth_encoding": "uint16 png",
+        },
+        "reporter_configs": config_names,
+        "sequences": sequence_metadata,
+    }
+
+
+def convert(
+    raw_dir: Path,
+    output_dir: Path,
+    sequences: Optional[Sequence[str]] = None,
+    *,
+    extract_sequence: Callable[[Path, Path], Path],
+) -> Dict[str, object]:
+    """Convert the selected sequences from ``raw_dir`` into ``output_dir``.
+
+    ``extract_sequence(archive, destination) -> Path`` unpacks one source archive
+    and returns the extracted sequence directory. It is injected so archive
+    safety stays in ``prepare.py`` and tests can convert from a plain directory.
+    """
+    selected = _selected_sequences(sequences)
+    raw_dir = Path(raw_dir)
+    output_dir = Path(output_dir)
+
+    missing = [
+        archive_name(sequence)
+        for sequence in selected
+        if not (raw_dir / archive_name(sequence)).is_file()
+    ]
+    if missing:
+        raise ConversionError(f"missing archive(s) in {raw_dir}: {', '.join(missing)}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    archive_metadata = []
+    sequence_metadata = []
+    for sequence in selected:
+        archive = raw_dir / archive_name(sequence)
+        archive_metadata.append({"name": archive.name, "sha256": _sha256(archive)})
+        print(f"Converting {sequence} …")
+        # Extract beside the output so a small /tmp cannot fail the conversion,
+        # and delete each extraction before starting the next sequence.
+        staging = output_dir.parent / f".tum_extract_{sequence}"
+        if staging.exists():
+            shutil.rmtree(staging)
+        staging.mkdir(parents=True)
+        try:
+            sequence_root = extract_sequence(archive, staging)
+            sequence_metadata.append(convert_sequence(sequence_root, sequence, output_dir))
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+    config_names = _write_configs(output_dir, selected)
+    metadata = _dataset_metadata(archive_metadata, config_names, sequence_metadata)
+    (output_dir / "dataset_metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return metadata

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/tum/download_tum.sh
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/tum/download_tum.sh
@@ -1,35 +1,81 @@
 #!/usr/bin/env bash
-# Download the TUM RGB-D (freiburg3 long_office_household) raw archive.
+# Download TUM RGB-D freiburg3 sequence archives.
 #
 # Usage: download_tum.sh [OPTIONS] [OUT_DIR]
 #
 #   OUT_DIR        Directory to save archives.
 #                  Defaults to <repo_root>/datasets/tum/raw
 #   --force        Re-download archives even when they already exist.
+#   --archive NAME Download only NAME. May be repeated. By default all 15
+#                  evaluated sequence archives are downloaded.
+#
+# The dataset pages serve /rgbd/dataset/freiburg3/<name>.tgz, which redirects to
+# a webshare host, so redirects must be followed. TUM publishes no per-file
+# checksums; the converter records a sha256 for each archive it consumes in
+# dataset_metadata.json instead.
 
 set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+# tum_download is the ordered list of sequence archives to fetch. Keep it in
+# sync with ALL_SEQS in convert_tum.py.
+
+readonly base_url="https://cvg.cit.tum.de/rgbd/dataset/freiburg3"
+
+readonly -a tum_download=(
+    "rgbd_dataset_freiburg3_sitting_halfsphere.tgz"
+    "rgbd_dataset_freiburg3_nostructure_texture_far.tgz"
+    "rgbd_dataset_freiburg3_nostructure_notexture_near_withloop.tgz"
+    "rgbd_dataset_freiburg3_teddy.tgz"
+    "rgbd_dataset_freiburg3_structure_texture_far.tgz"
+    "rgbd_dataset_freiburg3_walking_halfsphere.tgz"
+    "rgbd_dataset_freiburg3_structure_notexture_far.tgz"
+    "rgbd_dataset_freiburg3_sitting_xyz.tgz"
+    "rgbd_dataset_freiburg3_cabinet.tgz"
+    "rgbd_dataset_freiburg3_nostructure_texture_near_withloop.tgz"
+    "rgbd_dataset_freiburg3_nostructure_notexture_far.tgz"
+    "rgbd_dataset_freiburg3_sitting_xyz_validation.tgz"
+    "rgbd_dataset_freiburg3_structure_texture_near.tgz"
+    "rgbd_dataset_freiburg3_long_office_household.tgz"
+    "rgbd_dataset_freiburg3_large_cabinet_validation.tgz"
+)
+# ──────────────────────────────────────────────────────────────────────────────
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 repo_root="$(cd -- "${script_dir}/../../../../.." && pwd -P)"
 out_dir="${repo_root}/datasets/tum/raw"
 force=0
+requested_archives=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --force) force=1; shift ;;
+        --archive)
+            [[ $# -lt 2 ]] && { echo "error: --archive requires a value" >&2; exit 2; }
+            requested_archives+=("$2"); shift 2 ;;
         -*) echo "error: unknown option '$1'" >&2; exit 2 ;;
         *)  out_dir="$1"; shift ;;
     esac
 done
 
-readonly -a urls=(
-    "https://cvg.cit.tum.de/rgbd/dataset/freiburg3/rgbd_dataset_freiburg3_long_office_household.tgz"
-)
+download_names=("${tum_download[@]}")
+if [[ ${#requested_archives[@]} -gt 0 ]]; then
+    download_names=("${requested_archives[@]}")
+fi
 
-download_file() {
-    local url="$1"
-    local dest="${out_dir}/$(basename -- "${url}")"
+is_known_archive() {
+    local candidate="$1" known
+    for known in "${tum_download[@]}"; do
+        [[ "${known}" == "${candidate}" ]] && return 0
+    done
+    return 1
+}
+
+download_archive() {
+    local name="$1"
+    local dest="${out_dir}/${name}"
     local partial="${dest}.download"
+    local url="${base_url}/${name}"
 
     if [[ -s "${dest}" && "${force}" -eq 0 ]]; then
         echo "using existing ${dest}"
@@ -39,7 +85,7 @@ download_file() {
     mkdir -p "${out_dir}"
     [[ "${force}" -eq 1 ]] && rm -f -- "${dest}" "${partial}"
 
-    echo "downloading $(basename -- "${url}") …"
+    echo "downloading ${name} …"
     curl -fL --retry 5 --retry-delay 5 -C - -o "${partial}" "${url}"
 
     # curl -f only catches HTTP >=400; a 200 with an HTML error/landing page
@@ -48,7 +94,7 @@ download_file() {
     local magic
     magic="$(head -c 2 -- "${partial}" | od -An -tx1 | tr -d ' ')"
     if [[ "${magic}" != "1f8b" ]]; then
-        echo "error: $(basename -- "${url}") is not a gzip archive (magic '${magic}'); the server likely returned an error page" >&2
+        echo "error: ${name} is not a gzip archive (magic '${magic}'); the server likely returned an error page" >&2
         rm -f -- "${partial}"
         exit 1
     fi
@@ -56,8 +102,17 @@ download_file() {
     mv -f -- "${partial}" "${dest}"
 }
 
-for url in "${urls[@]}"; do
-    download_file "${url}"
+declare -A seen_archives=()
+for name in "${download_names[@]}"; do
+    if ! is_known_archive "${name}"; then
+        echo "error: '${name}' is not a known TUM archive; see tum_download in $(basename -- "${BASH_SOURCE[0]}")" >&2
+        exit 2
+    fi
+    if [[ -n "${seen_archives[${name}]:-}" ]]; then
+        continue
+    fi
+    seen_archives["${name}"]=1
+    download_archive "${name}"
 done
 
 echo "done — files saved to ${out_dir}"

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/tum/freiburg3_rig.yaml
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/tum/freiburg3_rig.yaml
@@ -1,8 +1,0 @@
-rgb_camera:
-  focal_length: [535.4, 539.2]
-  principal_point: [320.1, 247.6]
-  image_width: 640
-  image_height: 480
-
-depth_camera:
-  scale: 5000

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/tum/prepare.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/tum/prepare.py
@@ -12,32 +12,40 @@
 # By using, reproducing, modifying, distributing, performing, or displaying any portion or element
 # of the software or derivative works thereof, you agree to be bound by this License.
 
-"""Download the TUM RGB-D freiburg3 archive and lay out the sequence for the examples.
-
-This is provisioning only: it extracts the archive and copies the rig calibration
-into place. It does not convert the dataset to the cuVSLAM reporter format.
-"""
+"""Download the TUM RGB-D freiburg3 sequences and convert them to cuVSLAM data."""
 
 import argparse
-import shutil
 import tarfile
 from pathlib import Path, PurePosixPath
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from cuvslam_tools.dataset_preparation.common import (
     PreparationError,
     add_common_arguments,
     dataset_file,
+    require_nonempty_files,
     resolve_output_dir,
     resolve_raw_dir,
     run_download_script,
     run_preparation,
 )
 
-DATASET_NAME = "tum"
+from . import convert_tum
+
+DATASET_NAME = convert_tum.DATASET_ID
 DOWNLOAD_SCRIPT = "download_tum.sh"
-RIG_FILE = "freiburg3_rig.yaml"
-SEQUENCE_NAME = "rgbd_dataset_freiburg3_long_office_household"
+
+DATASET_ARTIFACTS = (
+    "dataset_metadata.json",
+    "tum-rgbd_slam.cfg",
+)
+SEQUENCE_ARTIFACTS = (
+    "stereo.edex",
+    "frame_metadata.jsonl",
+    "gt.txt",
+    "00/000000.png",
+    "01/000000.png",
+)
 
 
 def _check_member_path(member_path: str, description: str) -> None:
@@ -63,63 +71,98 @@ def extract_archive(archive: Path, destination: Path) -> None:
         raise PreparationError(f"failed to extract {archive}: {exc}") from exc
 
 
+def extract_sequence(archive: Path, destination: Path) -> Path:
+    """Extract one sequence archive and return the directory holding its files."""
+    extract_archive(archive, destination)
+    # Each TUM archive holds exactly one top-level directory named after the
+    # sequence, but locate it rather than assume, so a renamed archive fails here
+    # instead of midway through conversion.
+    candidates = [entry for entry in destination.iterdir() if entry.is_dir()]
+    if len(candidates) != 1:
+        names = ", ".join(sorted(entry.name for entry in candidates)) or "none"
+        raise PreparationError(
+            f"{archive.name}: expected one top-level directory in the archive, found: {names}"
+        )
+    return candidates[0]
+
+
 def prepare(
     raw_dir: Optional[Path] = None,
     output_dir: Optional[Path] = None,
+    sequences: Optional[Sequence[str]] = None,
     force_download: bool = False,
     download_only: bool = False,
 ) -> Path:
-    """Download and lay out the TUM RGB-D sequence, and return the prepared root.
+    """Download the required TUM archives, convert them, and return the prepared root.
 
-    Returns the raw directory when ``download_only`` is set, otherwise the sequence
-    directory holding the extracted data and the rig calibration.
+    Only the archives holding the selected sequences are downloaded.
+    ``sequences`` defaults to all 15 evaluated freiburg3 sequences. Returns the
+    raw directory when ``download_only`` is set, otherwise the converted root.
     """
     raw_dir = resolve_raw_dir(raw_dir, DATASET_NAME)
     output_dir = resolve_output_dir(output_dir)
+    # Only an omitted selection means "all 15"; an explicitly empty one is an
+    # error the converter reports, not a request to convert everything.
+    selected = list(sequences) if sequences is not None else None
 
     print(f"Raw dir    : {raw_dir}")
     print(f"Output dir : {output_dir}")
     print()
 
+    try:
+        archives = convert_tum.required_archives(selected)
+    except convert_tum.ConversionError as exc:
+        raise PreparationError(str(exc)) from exc
+
     download_arguments = [str(raw_dir)]
     if force_download:
         download_arguments.append("--force")
+    if selected is not None:
+        for archive in archives:
+            download_arguments.extend(["--archive", archive])
     run_download_script(dataset_file(__file__, DOWNLOAD_SCRIPT), download_arguments)
 
     if download_only:
         return raw_dir
 
     dataset_dir = output_dir / DATASET_NAME
-    sequence_dir = dataset_dir / SEQUENCE_NAME
-    archive = raw_dir / f"{SEQUENCE_NAME}.tgz"
+    print()
+    print(f"Converting TUM RGB-D data to {dataset_dir} …")
+    try:
+        convert_tum.convert(
+            raw_dir, dataset_dir, selected, extract_sequence=extract_sequence
+        )
+    except convert_tum.ConversionError as exc:
+        raise PreparationError(str(exc)) from exc
+
+    require_nonempty_files(dataset_dir, DATASET_ARTIFACTS, "converter")
+    for sequence in selected or convert_tum.ALL_SEQS:
+        require_nonempty_files(dataset_dir / sequence, SEQUENCE_ARTIFACTS, "converter")
 
     print()
-    print(f"Extracting {archive.name} …")
-    dataset_dir.mkdir(parents=True, exist_ok=True)
-    extract_archive(archive, dataset_dir)
-
-    if not sequence_dir.is_dir():
-        raise PreparationError(f"expected {sequence_dir} after extraction")
-
-    print("Copying rig calibration …")
-    shutil.copyfile(dataset_file(__file__, RIG_FILE), sequence_dir / RIG_FILE)
-
-    print()
-    print(f"done — dataset ready at {sequence_dir}")
-    return sequence_dir
+    print(f"done — portable TUM RGB-D dataset ready at {dataset_dir}")
+    return dataset_dir
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     """Parse command-line arguments and prepare the TUM RGB-D dataset."""
     parser = argparse.ArgumentParser(
         prog="prepare_tum",
-        description="Download and lay out the TUM RGB-D freiburg3 long_office_household dataset.",
+        description=(
+            "Download and convert the 15 evaluated TUM RGB-D freiburg3 sequences "
+            "to portable cuVSLAM EDEX data."
+        ),
     )
-    add_common_arguments(
-        parser,
-        DATASET_NAME,
-        label="TUM",
-        download_only_help="Download archives but skip dataset layout.",
+    add_common_arguments(parser, DATASET_NAME, label="TUM")
+    parser.add_argument(
+        "--sequences",
+        nargs="+",
+        choices=convert_tum.ALL_SEQS,
+        metavar="SEQUENCE",
+        help=(
+            "Convert an explicit sequence subset, such as "
+            "rgbd_dataset_freiburg3_long_office_household. The default is all 15 sequences."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -127,6 +170,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         lambda: prepare(
             raw_dir=args.raw_dir,
             output_dir=args.output_dir,
+            sequences=args.sequences,
             force_download=args.force_download,
             download_only=args.download_only,
         )

--- a/tools/python_tools/cuvslam_tools/tests/test_tum_conversion.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_tum_conversion.py
@@ -90,6 +90,19 @@ class TestTrajectory(unittest.TestCase):
         with self.assertRaisesRegex(rgbd.RgbdConversionError, "zero-length quaternion"):
             rgbd.read_tum_trajectory("1.0 0 0 0 0 0 0 0\n", "gt")
 
+    def test_extreme_quaternion_magnitudes_still_normalize(self):
+        # Squaring these overflows to infinity and underflows to zero
+        # respectively. Either one silently yields an all-zero quaternion, which
+        # quaternion_to_matrix then reads as an identity rotation.
+        for magnitude in ("1e308", "1e-200"):
+            with self.subTest(magnitude=magnitude):
+                rows = rgbd.read_tum_trajectory(f"1.0 0 0 0 {magnitude} 0 0 0\n", "gt")
+                self.assertEqual(rows[0][2], [1.0, 0.0, 0.0, 0.0])
+                self.assertEqual(
+                    rgbd.quaternion_to_matrix(rows[0][2]),
+                    [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]],
+                )
+
     def test_non_finite_pose_values_are_rejected(self):
         # float() accepts these, and they would otherwise reach every
         # interpolated pose as silently wrong ground truth.

--- a/tools/python_tools/cuvslam_tools/tests/test_tum_conversion.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_tum_conversion.py
@@ -1,0 +1,404 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+"""TUM RGB-D conversion: association, ground-truth handling, and emitted layout.
+
+The converter copies image bytes without decoding them, so the synthetic
+sequences below use placeholder file contents.
+"""
+
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+from cuvslam_tools.dataset_preparation import rgbd
+from cuvslam_tools.dataset_preparation.tum import convert_tum
+
+MILLISECOND_NS = 1_000_000
+
+
+def _index_text(entries):
+    lines = ["# color images", "# file: 'synthetic'", "# timestamp filename"]
+    lines += [f"{timestamp} {path}" for timestamp, path in entries]
+    return "\n".join(lines) + "\n"
+
+
+def _trajectory_text(rows):
+    lines = ["# ground truth trajectory", "# timestamp tx ty tz qx qy qz qw"]
+    for timestamp, translation, quaternion in rows:
+        values = " ".join(f"{value}" for value in list(translation) + list(quaternion))
+        lines.append(f"{timestamp} {values}")
+    return "\n".join(lines) + "\n"
+
+
+class TestTimestampIndex(unittest.TestCase):
+    def test_comments_and_blank_lines_are_skipped(self):
+        text = "# header\n\n1.000000 rgb/a.png\n1.033333 rgb/b.png\n"
+        entries = rgbd.read_timestamp_index(text, "rgb.txt")
+        self.assertEqual(entries, [(1_000_000_000, "rgb/a.png"), (1_033_333_000, "rgb/b.png")])
+
+    def test_timestamp_scales_exactly_to_nanoseconds(self):
+        # Parsed as Decimal, so the value does not depend on binary float rounding.
+        entries = rgbd.read_timestamp_index("1341847980.722988 rgb/a.png\n", "rgb.txt")
+        self.assertEqual(entries[0][0], 1_341_847_980_722_988_000)
+
+    def test_wrong_column_count_is_rejected(self):
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "expected 2 columns"):
+            rgbd.read_timestamp_index("1.0 rgb/a.png extra\n", "rgb.txt")
+
+    def test_non_increasing_timestamps_are_rejected(self):
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "strictly increasing"):
+            rgbd.read_timestamp_index("2.0 rgb/a.png\n1.0 rgb/b.png\n", "rgb.txt")
+
+    def test_empty_index_is_rejected(self):
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "no entries"):
+            rgbd.read_timestamp_index("# only a comment\n", "rgb.txt")
+
+
+class TestTrajectory(unittest.TestCase):
+    def test_quaternion_is_normalized(self):
+        text = "1.0 0 0 0 0 0 0 2\n"
+        rows = rgbd.read_tum_trajectory(text, "gt")
+        self.assertEqual(rows[0][2], [0.0, 0.0, 0.0, 1.0])
+
+    def test_wrong_column_count_is_rejected(self):
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "expected 8 columns"):
+            rgbd.read_tum_trajectory("1.0 0 0 0 0 0 0\n", "gt")
+
+    def test_zero_length_quaternion_is_rejected(self):
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "zero-length quaternion"):
+            rgbd.read_tum_trajectory("1.0 0 0 0 0 0 0 0\n", "gt")
+
+
+class TestAssociation(unittest.TestCase):
+    def test_closest_pair_wins_over_earlier_candidate(self):
+        # Depth at 5 ms and 11 ms; colour at 10 ms. Accepting the first candidate
+        # in stream order would take 5 ms, but 11 ms is closer.
+        color = [(10 * MILLISECOND_NS, "rgb/a.png")]
+        depth = [(5 * MILLISECOND_NS, "depth/a.png"), (11 * MILLISECOND_NS, "depth/b.png")]
+        matched = rgbd.associate(color, depth, 20 * MILLISECOND_NS)
+        self.assertEqual([pair[3] for pair in matched], ["depth/b.png"])
+
+    def test_each_frame_is_used_at_most_once(self):
+        color = [(10 * MILLISECOND_NS, "rgb/a.png"), (11 * MILLISECOND_NS, "rgb/b.png")]
+        depth = [(10 * MILLISECOND_NS, "depth/a.png")]
+        matched = rgbd.associate(color, depth, 20 * MILLISECOND_NS)
+        self.assertEqual(len(matched), 1)
+        self.assertEqual(matched[0][1], "rgb/a.png")
+
+    def test_tolerance_boundary_is_exclusive(self):
+        color = [(0, "rgb/a.png")]
+        depth = [(MILLISECOND_NS, "depth/a.png")]
+        with self.assertRaises(rgbd.RgbdConversionError):
+            rgbd.associate(color, depth, MILLISECOND_NS)
+        self.assertEqual(len(rgbd.associate(color, depth, MILLISECOND_NS + 1)), 1)
+
+    def test_result_is_sorted_by_colour_timestamp(self):
+        color = [(0, "rgb/a.png"), (100, "rgb/b.png"), (200, "rgb/c.png")]
+        depth = [(205, "depth/c.png"), (5, "depth/a.png"), (95, "depth/b.png")]
+        matched = rgbd.associate(color, depth, MILLISECOND_NS)
+        self.assertEqual([pair[0] for pair in matched], [0, 100, 200])
+
+    def test_non_positive_tolerance_is_rejected(self):
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "tolerance must be positive"):
+            rgbd.associate([(0, "a")], [(0, "b")], 0)
+
+
+class TestGroundTruthSampling(unittest.TestCase):
+    def _trajectory(self):
+        # Rotate 90 degrees about z between the two samples, translating in x.
+        half = math.sin(math.radians(45))
+        return [
+            (0, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]),
+            (1_000_000_000, [2.0, 0.0, 0.0], [0.0, 0.0, half, half]),
+        ]
+
+    def test_exact_sample_is_returned_unchanged(self):
+        trajectory = self._trajectory()
+        rotation, translation = rgbd.interpolate_pose(trajectory, [row[0] for row in trajectory], 0)
+        self.assertEqual(translation, [0.0, 0.0, 0.0])
+        self.assertAlmostEqual(rotation[0][0], 1.0)
+
+    def test_midpoint_interpolates_translation_and_rotation(self):
+        trajectory = self._trajectory()
+        rotation, translation = rgbd.interpolate_pose(
+            trajectory, [row[0] for row in trajectory], 500_000_000
+        )
+        self.assertAlmostEqual(translation[0], 1.0)
+        # Half of a 90 degree turn about z.
+        self.assertAlmostEqual(math.degrees(math.atan2(rotation[1][0], rotation[0][0])), 45.0)
+
+    def test_outside_range_clamps_to_the_end_samples(self):
+        trajectory = self._trajectory()
+        timestamps = [row[0] for row in trajectory]
+        _, before = rgbd.interpolate_pose(trajectory, timestamps, -1_000)
+        _, after = rgbd.interpolate_pose(trajectory, timestamps, 2_000_000_000)
+        self.assertEqual(before, [0.0, 0.0, 0.0])
+        self.assertEqual(after, [2.0, 0.0, 0.0])
+
+    def test_first_row_is_exactly_the_identity(self):
+        trajectory = self._trajectory()
+        pairs = [(0, "a", 0, "a"), (1_000_000_000, "b", 1_000_000_000, "b")]
+        lines = rgbd.relative_ground_truth_lines(trajectory, pairs)
+        self.assertEqual(len(lines), 2)
+        self.assertEqual([float(value) for value in lines[0].split()][0], 1.0)
+        self.assertEqual([float(value) for value in lines[0].split()][3], 0.0)
+
+    def test_poses_are_relative_to_the_first_frame(self):
+        # Frame 0 sits at the midpoint, so frame 1 must be 1 m ahead of it, not 2.
+        trajectory = self._trajectory()
+        pairs = [(500_000_000, "a", 500_000_000, "a"), (1_000_000_000, "b", 1_000_000_000, "b")]
+        lines = rgbd.relative_ground_truth_lines(trajectory, pairs)
+        values = [float(value) for value in lines[1].split()]
+        translation = [values[3], values[7], values[11]]
+        self.assertAlmostEqual(math.hypot(*translation[:2]), 1.0, places=6)
+
+    def test_frames_outside_the_trajectory_span_are_dropped(self):
+        trajectory = self._trajectory()
+        pairs = [
+            (-5, "early", -5, "early"),
+            (10, "inside", 10, "inside"),
+            (2_000_000_000, "late", 2_000_000_000, "late"),
+        ]
+        kept = rgbd.restrict_to_trajectory(pairs, trajectory)
+        self.assertEqual([pair[1] for pair in kept], ["inside"])
+
+    def test_no_frame_inside_the_span_is_rejected(self):
+        trajectory = self._trajectory()
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "inside the ground-truth"):
+            rgbd.restrict_to_trajectory([(2_000_000_000, "late", 2_000_000_000, "late")], trajectory)
+
+
+class TestSequenceSelection(unittest.TestCase):
+    def test_default_is_the_fifteen_evaluated_sequences(self):
+        self.assertEqual(len(convert_tum.ALL_SEQS), 15)
+        self.assertEqual(len(set(convert_tum.ALL_SEQS)), 15)
+        self.assertEqual(len(convert_tum.required_archives()), 15)
+
+    def test_every_sequence_is_from_the_freiburg3_series(self):
+        # One intrinsics set covers the selection only because all of it is fr3.
+        for sequence in convert_tum.ALL_SEQS:
+            self.assertTrue(sequence.startswith("rgbd_dataset_freiburg3_"), sequence)
+
+    def test_unknown_sequence_is_rejected(self):
+        with self.assertRaisesRegex(convert_tum.ConversionError, "unknown sequence"):
+            convert_tum.required_archives(["rgbd_dataset_freiburg1_desk"])
+
+    def test_duplicate_sequence_is_rejected(self):
+        name = convert_tum.ALL_SEQS[0]
+        with self.assertRaisesRegex(convert_tum.ConversionError, "duplicate sequence"):
+            convert_tum.required_archives([name, name])
+
+    def test_empty_selection_is_rejected(self):
+        with self.assertRaisesRegex(convert_tum.ConversionError, "no sequences selected"):
+            convert_tum.required_archives([])
+
+    def test_selection_order_follows_the_report_order(self):
+        requested = [convert_tum.ALL_SEQS[3], convert_tum.ALL_SEQS[1]]
+        self.assertEqual(
+            convert_tum.required_archives(requested),
+            [convert_tum.archive_name(convert_tum.ALL_SEQS[1]),
+             convert_tum.archive_name(convert_tum.ALL_SEQS[3])],
+        )
+
+    def test_downloader_lists_exactly_the_selected_archives(self):
+        script = (
+            Path(convert_tum.__file__).resolve().with_name("download_tum.sh")
+        ).read_text(encoding="utf-8")
+        listed = {
+            line.strip().strip('"')
+            for line in script.splitlines()
+            if line.strip().startswith('"rgbd_dataset_freiburg3_')
+        }
+        self.assertEqual(listed, set(convert_tum.required_archives()))
+
+
+class TestConvertSequence(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self._temporary.name)
+        self.sequence = convert_tum.ALL_SEQS[0]
+
+    def tearDown(self):
+        self._temporary.cleanup()
+
+    def _write_source(self, frame_count=4, step_ns=33_000_000):
+        source = self.root / "source"
+        (source / "rgb").mkdir(parents=True)
+        (source / "depth").mkdir(parents=True)
+        color_entries = []
+        depth_entries = []
+        for index in range(frame_count):
+            timestamp = 1_000_000_000 + index * step_ns
+            color_name = f"rgb/{timestamp}.png"
+            depth_name = f"depth/{timestamp}.png"
+            (source / color_name).write_bytes(b"color-" + str(index).encode())
+            (source / depth_name).write_bytes(b"depth-" + str(index).encode())
+            color_entries.append((_seconds(timestamp), color_name))
+            # Depth lags colour by 20 us, as the real streams do.
+            depth_entries.append((_seconds(timestamp + 20_000), depth_name))
+        (source / "rgb.txt").write_text(_index_text(color_entries), encoding="utf-8")
+        (source / "depth.txt").write_text(_index_text(depth_entries), encoding="utf-8")
+
+        span = step_ns * (frame_count - 1)
+        rows = [
+            (_seconds(1_000_000_000 - step_ns), [0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]),
+            (_seconds(1_000_000_000 + span + step_ns), [1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]),
+        ]
+        (source / "groundtruth.txt").write_text(_trajectory_text(rows), encoding="utf-8")
+        return source
+
+    def test_emits_the_expected_layout(self):
+        source = self._write_source()
+        output = self.root / "out"
+        metadata = convert_tum.convert_sequence(source, self.sequence, output)
+
+        sequence_dir = output / self.sequence
+        self.assertEqual(metadata["converted_counts"]["frames"], 4)
+        self.assertEqual(
+            sorted(entry.name for entry in sequence_dir.iterdir()),
+            ["00", "01", "frame_metadata.jsonl", "gt.txt", "stereo.edex"],
+        )
+        self.assertEqual(
+            sorted(entry.name for entry in (sequence_dir / "00").iterdir()),
+            [f"{index:06d}.png" for index in range(4)],
+        )
+        # Colour lands in 00 and depth in 01, and the bytes are copied verbatim.
+        self.assertEqual((sequence_dir / "00" / "000002.png").read_bytes(), b"color-2")
+        self.assertEqual((sequence_dir / "01" / "000002.png").read_bytes(), b"depth-2")
+
+    def test_frame_metadata_pairs_colour_with_depth(self):
+        source = self._write_source()
+        output = self.root / "out"
+        convert_tum.convert_sequence(source, self.sequence, output)
+
+        lines = (output / self.sequence / "frame_metadata.jsonl").read_text().splitlines()
+        self.assertEqual(len(lines), 4)
+        first = json.loads(lines[0])
+        self.assertEqual(first["frame_id"], 0)
+        self.assertEqual(first["cams"], [{"filename": "00/000000.png", "id": 0, "timestamp": 1_000_000_000}])
+        self.assertEqual(
+            first["depth"], [{"filename": "01/000000.png", "id": 0, "timestamp": 1_000_020_000}]
+        )
+
+    def test_edex_describes_one_rgbd_camera(self):
+        source = self._write_source()
+        output = self.root / "out"
+        convert_tum.convert_sequence(source, self.sequence, output)
+
+        document = json.loads((output / self.sequence / "stereo.edex").read_text())
+        rig, metadata = document
+        self.assertEqual(rig["frame_start"], 0)
+        self.assertEqual(rig["frame_end"], 3)
+        camera = rig["cameras"][0]
+        self.assertEqual(camera["intrinsics"]["focal"], [535.4, 539.2])
+        self.assertEqual(camera["intrinsics"]["principal"], [320.1, 247.6])
+        self.assertEqual(camera["intrinsics"]["size"], [640, 480])
+        self.assertEqual(camera["intrinsics"]["distortion_model"], "pinhole")
+        self.assertEqual(camera["depth_id"], 0)
+        # 16-bit PNG depth in TUM units. Without this the reader would divide by
+        # 1, and depth would be read as thousands of metres.
+        self.assertEqual(camera["depth_scale_factor"], 5000.0)
+        self.assertEqual(metadata["frame_metadata"], "frame_metadata.jsonl")
+        self.assertEqual(metadata["depth_sequence"], [["01/000000.png"]])
+
+    def test_ground_truth_has_one_row_per_frame(self):
+        source = self._write_source()
+        output = self.root / "out"
+        convert_tum.convert_sequence(source, self.sequence, output)
+
+        rows = (output / self.sequence / "gt.txt").read_text().splitlines()
+        self.assertEqual(len(rows), 4)
+        for row in rows:
+            self.assertEqual(len(row.split()), 12)
+
+    def test_missing_index_file_is_reported(self):
+        source = self._write_source()
+        (source / "groundtruth.txt").unlink()
+        with self.assertRaisesRegex(convert_tum.ConversionError, "missing groundtruth.txt"):
+            convert_tum.convert_sequence(source, self.sequence, self.root / "out")
+
+    def test_missing_image_is_reported(self):
+        source = self._write_source()
+        (source / "depth").joinpath(sorted(p.name for p in (source / "depth").iterdir())[0]).unlink()
+        with self.assertRaisesRegex(convert_tum.ConversionError, "missing image"):
+            convert_tum.convert_sequence(source, self.sequence, self.root / "out")
+
+    def test_rerunning_replaces_the_previous_output(self):
+        source = self._write_source()
+        output = self.root / "out"
+        convert_tum.convert_sequence(source, self.sequence, output)
+        stale = output / self.sequence / "00" / "999999.png"
+        stale.write_bytes(b"stale")
+        convert_tum.convert_sequence(source, self.sequence, output)
+        self.assertFalse(stale.exists())
+
+
+class TestReporterConfig(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.output = Path(self._temporary.name)
+
+    def tearDown(self):
+        self._temporary.cleanup()
+
+    def _config(self, sequences=None):
+        selected = list(sequences or convert_tum.ALL_SEQS)
+        names = convert_tum._write_configs(self.output, selected)
+        return names, json.loads((self.output / names[0]).read_text())
+
+    def test_one_config_covers_every_sequence_in_both_modes(self):
+        names, config = self._config()
+        self.assertEqual(names, ["tum-rgbd_slam.cfg"])
+        self.assertEqual(len(config["sequence_cfgs"]), 30)
+
+    def test_dataset_folder_matches_the_registry_id(self):
+        _, config = self._config()
+        self.assertEqual(config["dataset_folder"], "tum/")
+
+    def test_config_name_derives_the_intended_kpi_prefix(self):
+        names, _ = self._config()
+        # The KPI collector takes everything before the first hyphen, uppercased.
+        self.assertEqual(Path(names[0]).stem.split("-")[0].upper(), "TUM")
+
+    def test_every_entry_names_its_edex_and_ground_truth(self):
+        # The retired config omitted gt_file_path, which makes the reporter run
+        # the sequence with no ground truth instead of failing.
+        _, config = self._config()
+        for entry in config["sequence_cfgs"]:
+            self.assertEqual(entry["edex_file"], "stereo.edex")
+            self.assertEqual(entry["gt_file_path"], "gt.txt")
+            self.assertTrue(entry["enable"])
+
+    def test_titles_pair_one_odom_and_one_slam_per_sequence(self):
+        _, config = self._config([convert_tum.ALL_SEQS[7]])
+        titles = [entry["sequence_title"] for entry in config["sequence_cfgs"]]
+        self.assertEqual(titles, ["freiburg3-sitting-xyz-ODOM", "freiburg3-sitting-xyz-SLAM"])
+        self.assertNotIn("use_slam", config["sequence_cfgs"][0])
+        self.assertTrue(config["sequence_cfgs"][1]["use_slam"])
+
+    def test_segment_lengths_match_the_other_converters(self):
+        _, config = self._config()
+        self.assertEqual(config["segment_lengths"], [1, 2, 3, 5, 7.5, 10, 15, 20, 25, 35, 45])
+
+
+def _seconds(nanoseconds):
+    """Render nanoseconds as a TUM-style fixed-point seconds string."""
+    return f"{nanoseconds // 1_000_000_000}.{nanoseconds % 1_000_000_000:09d}"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/python_tools/cuvslam_tools/tests/test_tum_conversion.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_tum_conversion.py
@@ -63,6 +63,14 @@ class TestTimestampIndex(unittest.TestCase):
         with self.assertRaisesRegex(rgbd.RgbdConversionError, "strictly increasing"):
             rgbd.read_timestamp_index("2.0 rgb/a.png\n1.0 rgb/b.png\n", "rgb.txt")
 
+    def test_non_finite_timestamps_are_rejected(self):
+        # Decimal accepts these, and converting them to an integer raises
+        # outside the module's error contract unless they are caught first.
+        for text in ("inf", "-inf", "Infinity", "nan"):
+            with self.subTest(timestamp=text):
+                with self.assertRaises(rgbd.RgbdConversionError):
+                    rgbd.read_timestamp_index(f"{text} rgb/a.png\n", "rgb.txt")
+
     def test_empty_index_is_rejected(self):
         with self.assertRaisesRegex(rgbd.RgbdConversionError, "no entries"):
             rgbd.read_timestamp_index("# only a comment\n", "rgb.txt")
@@ -81,6 +89,14 @@ class TestTrajectory(unittest.TestCase):
     def test_zero_length_quaternion_is_rejected(self):
         with self.assertRaisesRegex(rgbd.RgbdConversionError, "zero-length quaternion"):
             rgbd.read_tum_trajectory("1.0 0 0 0 0 0 0 0\n", "gt")
+
+    def test_non_finite_pose_values_are_rejected(self):
+        # float() accepts these, and they would otherwise reach every
+        # interpolated pose as silently wrong ground truth.
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "non-finite pose value"):
+            rgbd.read_tum_trajectory("1.0 inf 0 0 0 0 0 1\n", "gt")
+        with self.assertRaisesRegex(rgbd.RgbdConversionError, "non-finite pose value"):
+            rgbd.read_tum_trajectory("1.0 0 0 0 nan 0 0 1\n", "gt")
 
 
 class TestAssociation(unittest.TestCase):
@@ -107,10 +123,27 @@ class TestAssociation(unittest.TestCase):
         self.assertEqual(len(rgbd.associate(color, depth, MILLISECOND_NS + 1)), 1)
 
     def test_result_is_sorted_by_colour_timestamp(self):
-        color = [(0, "rgb/a.png"), (100, "rgb/b.png"), (200, "rgb/c.png")]
-        depth = [(205, "depth/c.png"), (5, "depth/a.png"), (95, "depth/b.png")]
+        # Offsets shrink along the sequence, so closest-first consumes the last
+        # colour frame first and the output order comes from the final sort
+        # rather than the scan order. Both indices are sorted, as
+        # read_timestamp_index guarantees for real input.
+        color = [(0, "rgb/a.png"), (100_000, "rgb/b.png"), (200_000, "rgb/c.png")]
+        depth = [(50_000, "depth/a.png"), (130_000, "depth/b.png"), (200_000, "depth/c.png")]
         matched = rgbd.associate(color, depth, MILLISECOND_NS)
-        self.assertEqual([pair[0] for pair in matched], [0, 100, 200])
+        self.assertEqual([pair[0] for pair in matched], [0, 100_000, 200_000])
+        self.assertEqual(
+            [pair[3] for pair in matched],
+            ["depth/a.png", "depth/b.png", "depth/c.png"],
+        )
+
+    def test_window_pairs_every_frame_when_the_tolerance_is_tight(self):
+        # A tolerance on the scale of the data, rather than one that spans the
+        # whole index, is what exercises the sliding window.
+        color = [(0, "rgb/a.png"), (100_000, "rgb/b.png"), (200_000, "rgb/c.png")]
+        depth = [(1_000, "depth/a.png"), (101_000, "depth/b.png"), (201_000, "depth/c.png")]
+        matched = rgbd.associate(color, depth, 2_000)
+        self.assertEqual(len(matched), 3)
+        self.assertEqual([pair[1] for pair in matched], ["rgb/a.png", "rgb/b.png", "rgb/c.png"])
 
     def test_non_positive_tolerance_is_rejected(self):
         with self.assertRaisesRegex(rgbd.RgbdConversionError, "tolerance must be positive"):

--- a/tools/python_tools/cuvslam_tools/tests/test_tum_preparation.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_tum_preparation.py
@@ -12,7 +12,7 @@
 # By using, reproducing, modifying, distributing, performing, or displaying any portion or element
 # of the software or derivative works thereof, you agree to be bound by this License.
 
-"""Archive extraction safety for the TUM RGB-D preparation.
+"""Archive extraction safety and sequence discovery for the TUM RGB-D preparation.
 
 Extraction is hand-rolled on Python tarfile instead of tar, which validates
 member names and link targets separately. One case covers each branch.
@@ -56,13 +56,47 @@ class TestTumSafeExtraction(unittest.TestCase):
 
     def test_traversing_link_target_is_rejected(self):
         def build(tar):
-            info = tarfile.TarInfo(f"{tum_prepare.SEQUENCE_NAME}/link")
+            info = tarfile.TarInfo("rgbd_dataset_freiburg3_cabinet/link")
             info.type = tarfile.SYMTYPE
             info.linkname = "../../outside"
             tar.addfile(info)
 
         with self.assertRaisesRegex(PreparationError, "unsafe link target"):
             tum_prepare.extract_archive(self._archive(build), self.destination)
+
+
+class TestTumSequenceDiscovery(unittest.TestCase):
+    """extract_sequence locates the sequence directory rather than assuming its name."""
+
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self._temporary.name)
+        self.destination = self.root / "out"
+        self.destination.mkdir()
+
+    def tearDown(self):
+        self._temporary.cleanup()
+
+    def _archive(self, directories) -> Path:
+        archive = self.root / "archive.tgz"
+        with tarfile.open(archive, "w:gz") as tar:
+            for directory in directories:
+                info = tarfile.TarInfo(f"{directory}/rgb.txt")
+                payload = b"# timestamp filename\n"
+                info.size = len(payload)
+                tar.addfile(info, io.BytesIO(payload))
+        return archive
+
+    def test_single_directory_is_returned(self):
+        archive = self._archive(["rgbd_dataset_freiburg3_teddy"])
+        extracted = tum_prepare.extract_sequence(archive, self.destination)
+        self.assertEqual(extracted.name, "rgbd_dataset_freiburg3_teddy")
+        self.assertTrue((extracted / "rgb.txt").is_file())
+
+    def test_unexpected_archive_shape_is_reported(self):
+        archive = self._archive(["first", "second"])
+        with self.assertRaisesRegex(PreparationError, "expected one top-level directory"):
+            tum_prepare.extract_sequence(archive, self.destination)
 
 
 if __name__ == "__main__":

--- a/tools/python_tools/pyproject.toml
+++ b/tools/python_tools/pyproject.toml
@@ -37,7 +37,7 @@ where = ["."]
 "cuvslam_tools.dataset_preparation.kitti" = ["download_*.sh"]
 "cuvslam_tools.dataset_preparation.euroc" = ["download_*.sh"]
 "cuvslam_tools.dataset_preparation.tartan.dataset_converter" = ["cfg/*.json"]
-"cuvslam_tools.dataset_preparation.tum" = ["download_*.sh", "*.yaml"]
+"cuvslam_tools.dataset_preparation.tum" = ["download_*.sh"]
 "cuvslam_tools.reporter" = ["report_templates/*.html"]
 "cuvslam_tools.datasets_validator" = ["configs/*.cfg"]
 


### PR DESCRIPTION
TUM preparation only downloaded and unpacked one sequence in native layout; it produced no EDEX, so provisioning the dataset would have uploaded a tarball the reporter cannot read.

Add a shared dataset_preparation/rgbd.py with the primitives ICL-NUIM and AR Table will reuse (colour/depth association, ground-truth interpolation, and the EDEX, frame-metadata, and reporter-config writers), and a TUM converter on top of it covering the 15 freiburg3 sequences the retired nightly evaluated.

Three deliberate departures from the retired pipeline, each validated against its output for freiburg3_long_office_household:

- Depth is copied as 16-bit PNG with depth_scale_factor 5000 instead of being expanded to float32 npy. The reader accepts a PNG directly and quantised the float back to whole millimetres anyway, so the extra step only cost precision and 2.7x the disk.
- Colour and depth are associated within 1 ms, which pairs the two views of one capture. The retired output never exceeds 990 us, and relaxing to half a frame interval pairs frames up to 8.2 ms apart.
- Each reporter entry names its gt_file_path. Omitting it, as the retired config did, makes the reporter run the sequence with no ground truth rather than fail.

Ground truth agrees with the retired output to 2.1 mm over a 4.4 m trajectory once both are referenced to a common first frame. Frame selection is a superset: 2442 against 2360, with all 2360 included. The remaining 82-frame difference is not reproducible from the published data, and neither association tolerance, ground-truth gaps, depth content, duplicate frames, nor a frame-rate limit explains it.

The bundled freiburg3_rig.yaml is removed: the intrinsics now live in the converter, and examples/tum keeps its own copy for the tutorial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for downloading and converting all 15 evaluated Freiburg3 TUM RGB-D sequences by default.
  - Added optional sequence selection during preparation.
  - Generated portable EDEX data, frame metadata, relative ground truth, calibration, and reporter configuration.
  - Added RGB-D frame association, pose interpolation, validation, and conversion statistics.
  - Added safer archive handling and validation for incomplete or unexpected dataset contents.

- **Documentation**
  - Expanded preparation guidance with sequence selection, outputs, frame pairing, calibration, and reporting examples.

- **Tests**
  - Added comprehensive coverage for conversion, validation, archive handling, sequence selection, metadata, and ground-truth generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->