### PR TITLE
[test] align depth point map test with the near plane guard

### DIFF
--- a/libs/map/test/depth_point_map_test.cpp
+++ b/libs/map/test/depth_point_map_test.cpp
@@ -21,6 +21,7 @@
 #include "common/isometry.h"
 #include "common/vector_3t.h"
 #include "cuda_modules/cuda_helper.h"
+#include "epipolar/camera_selection.h"
 
 #include "map/depth_point_map.h"
 
@@ -230,14 +231,18 @@ TEST(DepthPointMapTest, CloseButOffFrustumPointsAreKept) {
   std::vector<cuvslam::map::DepthCameraInfo> cams1{cam.info(pose1)};
 
   // Record which old points are still "close" to the new camera pose. All of
-  // these MUST still be present after update().
+  // these MUST still be present after update(). The near bound has to be the
+  // same IsDepthInFront the eviction predicate uses: a point the yaw pushed
+  // inside the near plane is legitimately dropped, so expecting it back here
+  // would pin the boundary this test is not about.
   std::vector<Vector3T> close_before = map.get_points();
-  close_before.erase(std::remove_if(close_before.begin(), close_before.end(),
-                                    [&](const Vector3T& p) {
-                                      const Vector3T p_cam = pose1.inverse() * p;
-                                      return !(p_cam.z() > 0.f && p_cam.z() <= settings.visible_max_depth);
-                                    }),
-                     close_before.end());
+  close_before.erase(
+      std::remove_if(close_before.begin(), close_before.end(),
+                     [&](const Vector3T& p) {
+                       const Vector3T p_cam = pose1.inverse() * p;
+                       return !(epipolar::IsDepthInFront(p_cam.z()) && p_cam.z() <= settings.visible_max_depth);
+                     }),
+      close_before.end());
   ASSERT_FALSE(close_before.empty()) << "Test precondition: at least some points should still be close.";
 
   map.update(cams1);


### PR DESCRIPTION
#116 moved close_to_cam onto epipolar::IsDepthInFront, which rejects depths at or below MINIMUM_HITHER (0.1) rather than merely non-positive ones. CloseButOffFrustumPointsAreKept predates that change and builds its own expectation with a hand-written z > 0, so the ~57 degree yaw it applies leaves some points with depth in (0, 0.1]. The map correctly evicts those; the test demanded them back and failed on x86, Orin, and Thor, leaving main red since #116 merged.

Share the guard the implementation uses instead of restating the bound, which is the whole point of routing these predicates through IsDepthInFront. The test's actual subject is unchanged: points that are close but off the image rect must survive the distance-only eviction pass.

Product code is untouched. Verified locally that map_test fails on the unmodified test and all 13 cases pass with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected depth-point map testing for points near the camera’s clipping plane.
  * Improved consistency between point retention and eviction behavior for off-frustum points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->