### PR TITLE
[infra] require PR status check on main ruleset

### DIFF
--- a/.github/rulesets/default-branch-ruleset.json
+++ b/.github/rulesets/default-branch-ruleset.json
@@ -33,7 +33,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
           { "context": "PR status", "integration_id": 15368 }

--- a/.github/rulesets/default-branch-ruleset.json
+++ b/.github/rulesets/default-branch-ruleset.json
@@ -1,7 +1,7 @@
 {
   "name": "Main branch protection",
   "target": "branch",
-  "enforcement": "evaluate",
+  "enforcement": "active",
   "conditions": {
     "ref_name": {
       "include": ["~DEFAULT_BRANCH"],
@@ -16,31 +16,30 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_linear_history"
+    },
+    {
       "type": "pull_request",
       "parameters": {
-        "dismiss_stale_reviews_on_push": true,
+        "dismiss_stale_reviews_on_push": false,
         "require_code_owner_review": true,
         "require_last_push_approval": true,
-        "required_approving_review_count": 3,
-        "required_review_thread_resolution": true
+        "require_extra_approval_for_unattributed_changes": true,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["squash"]
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
-          { "context": "PR status" }
+          { "context": "PR status", "integration_id": 15368 }
         ]
       }
     }
   ],
-  "bypass_actors": [
-    {
-      "actor_id": 1,
-      "actor_type": "OrganizationAdmin",
-      "bypass_mode": "always"
-    }
-  ]
+  "bypass_actors": []
 }

--- a/.github/rulesets/default-branch-ruleset.json
+++ b/.github/rulesets/default-branch-ruleset.json
@@ -41,5 +41,11 @@
       }
     }
   ],
-  "bypass_actors": []
+  "bypass_actors": [
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
 }


### PR DESCRIPTION
The checked-in ruleset never gated anything: it sat on `evaluate` enforcement, which
reports violations without blocking a merge. #116 merged red under it and broke `main`.

- `enforcement`: `evaluate` → `active`.
- Pin the required `PR status` check to `integration_id: 15368` (GitHub Actions).
  Unpinned it accepts any source, so any token with write access can satisfy the gate
  by posting a commit status with no build behind it. `PR status` is also the only safe
  context to require: the build jobs are fork-gated and never report on fork PRs, while
  `pr-status` runs `if: always()` and already aggregates lint plus every build.
- Match the `pull_request` parameters to the ruleset currently live on `main`, which was
  configured by hand while this file sat unapplied: linear history, squash-only merges,
  one approving review (was 3), and stale-review dismissal off — which
  `require_last_push_approval` already covers.

This does not take effect on merge: `sync-rulesets.yml` has failed on every run since
`RULESET_ADMIN_TOKEN` was never set, and the live ruleset was updated by hand to match.
This change makes the file correct for when the token is provisioned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Default-branch protection rules are now actively enforced.
  - Pull requests require at least one approval, with additional approval required for unattributed changes.
  - Existing approvals are retained when new commits are pushed.
  - Required status checks and integration validation have been updated.
  - Linear commit history is required for changes to the default branch.
  - Merges must use the squash method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->