### PR TITLE
[refactor] centralize dataset definitions in a typed Python registry

### DIFF
--- a/cuvslam-skills/cuvslam-ci/SKILL.md
+++ b/cuvslam-skills/cuvslam-ci/SKILL.md
@@ -23,14 +23,14 @@ Workflows (`.github/workflows/`):
 CI scripts (`scripts/`):
 
 - `Dockerfile.ci` - the shared `cuvslam-ci:local` image (git, python3, pre-commit, GPG-verified AWS CLI, jq).
-- `datasets_config.sh` - dataset registry: `PROVISIONABLE_DATASETS`, `EVAL_DATASET_NAMES`, path helpers, `s3_tarball_uri` (names `<name>.tar`).
-- `provision_dataset.sh` - runs the dataset preparation module (`python3 -m cuvslam_tools.dataset_preparation.<name>.prepare` with `PYTHONPATH=tools/python_tools`), tars the converted output (uncompressed `.tar`), uploads to S3.
-- `stage_eval_datasets.sh` - downloads `<name>.tar` from S3, extracts to the local cache.
+- `datasets_config.sh` - S3 location plus the `dataset_registry` shell shim; dataset names and evaluation records live in `tools/python_tools/cuvslam_tools/dataset_registry.py`.
+- `provision_dataset.sh` - runs `dataset_registry prepare`, tars the directory `prepare()` returned (uncompressed `.tar`), uploads to S3.
+- `stage_eval_datasets.sh` - validates the registry, downloads each eval dataset's `<id>.tar` from S3, streams it into the local cache, and checks the staged reporter config against the registry.
 - `check_eval_prerequisites.sh` - verifies credentials/cache and `RUNNER_STORAGE_ROOT`.
 - `benchmark_cuvslam_in_docker.sh` - runs the active `cuda_modules_test` speed benchmarks in the product container and captures runner metadata, raw output, and GoogleTest XML.
 - `cuvslam_benchmark_report.py` - validates benchmark XML properties and renders per-Jetson JSON and Markdown reports.
 - `eval_cuvslam_in_docker.sh` - host wrapper: mounts datasets and KPI history, starts the eval container.
-- `run_eval.sh` - in container: the active dataset set `DATASETS[]`, runs `cuvslam_app.py`, then collects
+- `run_eval.sh` - in container: reads evaluation records from the registry, runs `cuvslam_app.py`, then collects
   machine-readable KPI JSON.
 - `cuvslam_kpi_report.py` - owns KPI collection, rolling diffs, cross-config aggregation, soft drift data, and all
   KPI Markdown rendering. `collect` writes raw and report JSON; `render` and `aggregate` produce publication Markdown.
@@ -43,12 +43,14 @@ Dataset tooling: `tools/python_tools/cuvslam_tools/dataset_preparation/<name>/` 
 
 ## Task: add a dataset
 
-1. In `scripts/datasets_config.sh`, add the name to `PROVISIONABLE_DATASETS` and add its `dataset_upload_subdir` case (empty string means the converted root; otherwise the subdir under the converted output).
-2. Add `tools/python_tools/cuvslam_tools/dataset_preparation/<name>/prepare.py` (plus a downloader) exposing `prepare()` and `main()`, which converts raw data to the edex layout under `--output-dir`. `provision_dataset.sh` resolves the module as `cuvslam_tools.dataset_preparation.<name>.prepare` and requires it to accept `--raw-dir`, `--output-dir`, and `--force-download`.
-3. Add the dataset to the `dataset` choice input in `provision-datasets.yml`.
-4. Run Provision dataset (`workflow_dispatch`) on the default branch. It writes `<S3_DATASETS_BUCKET>/<name>.tar`.
-5. Add the name to `EVAL_DATASET_NAMES` in `datasets_config.sh`, and add a record to `DATASETS[]` in `scripts/run_eval.sh`: `LABEL|link_name|subdir|test_config|app_flags`.
-6. Add expected KPI ranges for the dataset to `scripts/kpi_baseline_ranges.json`.
+The dataset ID is the only name: it is the preparation module, the `<id>.tar` object, the staged directory, and the `/sequences` mount.
+
+1. Add `tools/python_tools/cuvslam_tools/dataset_preparation/<id>/prepare.py` (plus a downloader) exposing `prepare()` and `main()`. It must accept `--raw-dir`, `--output-dir`, and `--force-download`, and **return the directory to archive** — that directory becomes the tar root and the staged dataset root. Each generated reporter config must set `"dataset_folder": "<id>/"`.
+2. Add a `DatasetSpec` to `DATASETS` in `tools/python_tools/cuvslam_tools/dataset_registry.py` with the ID and the preparation module, and no `evals` yet. Run `python3 -m cuvslam_tools.dataset_registry validate`.
+3. Add the ID to the `dataset` choice input in `provision-datasets.yml`. A registry test asserts every choice resolves.
+4. Run Provision dataset (`workflow_dispatch`) on the default branch. It writes `<S3_DATASETS_BUCKET>/<id>.tar`.
+5. Enable evaluation by adding one or more `EvalSpec` records to that `DatasetSpec`: the reporter config filename, the `cuvslam_app` flags, and suite membership. Nothing else needs editing; staging and eval both read the registry.
+6. Add expected KPI ranges to `scripts/kpi_baseline_ranges.json`. The key prefix is derived from the config filename (first hyphen-delimited token, upper-cased), so name configs with underscores inside the prefix and a hyphen only as its terminator: `tartan_flaky-vo_slam.cfg` gives `TARTAN_FLAKY`, whereas `tartan-flaky-vo_slam.cfg` would collide with `TARTAN`.
 
 ## Task: change dataset format or packing
 

--- a/cuvslam-skills/cuvslam-ci/SKILL.md
+++ b/cuvslam-skills/cuvslam-ci/SKILL.md
@@ -68,7 +68,7 @@ Do not reintroduce gzip: provisioning uses uncompressed `.tar` to cap memory on 
 - Nightly configs: `nightly.yml` `strategy.matrix.include`. Eval runs on entries flagged `eval: true` (currently the four x86 configs). Every eval-enabled config needs the `RUNNER_STORAGE_ROOT` mount and configured repo secrets/variables; the `cuvslam-ci:local` image supplies the AWS CLI.
 - Jetson CUDA micro-benchmarks run only on nightly entries flagged `benchmark: true` (currently Orin and Thor). The normal C++ test invocation continues to exclude `*SpeedUp*` and `*Speedup*`; the dedicated benchmark wrapper runs the positive filter and excludes `DISABLED_` tests.
 - PR config: `pr-verify.yml` runs eval only on `build-test-x86` (fork-gated). `EVAL_CONFIG` is the static slug label for the PR table.
-- Active dataset set: `DATASETS[]` in `run_eval.sh` is global; PR and nightly run the same set. There is no per-pipeline dataset selection today. To run a different set in PR vs nightly, add an env-selected subset in `run_eval.sh` and have each workflow pass the selector.
+- Active dataset set: `run_eval.sh` reads every record from `dataset_registry eval-records`, so PR and nightly run the same set. There is no per-pipeline selection today. To differ, filter the records by suite in the registry and have each workflow pass the selector; `EvalSpec.suites` already carries the membership.
 
 ## Task: preserve nightly version provenance
 

--- a/cuvslam-skills/cuvslam-ci/reference.md
+++ b/cuvslam-skills/cuvslam-ci/reference.md
@@ -28,7 +28,7 @@ flowchart TD
     prereq --> build --> stage --> wrapper
   end
   subgraph container [cuvslam:local container]
-    inner["run_eval.sh (DATASETS[])"]
+    inner["run_eval.sh (registry eval-records)"]
     app["cuvslam_app.py per dataset"]
     kpi["cuvslam_kpi_report.py collect\nraw + report JSON"]
     inner --> app --> kpi

--- a/cuvslam-skills/cuvslam-ci/reference.md
+++ b/cuvslam-skills/cuvslam-ci/reference.md
@@ -66,10 +66,11 @@ Repository secrets, split read from write so fork-reachable jobs never hold a ke
 
 ## Dataset registry and layout
 
-- `PROVISIONABLE_DATASETS` (datasets the Provision workflow can build) and `EVAL_DATASET_NAMES` (datasets eval stages) live in `datasets_config.sh`.
-- `run_eval.sh` `DATASETS[]` records are pipe-delimited: `LABEL|link_name|subdir|test_config|app_flags`. KITTI and
-  EuRoC are active; the others are commented until provisioned.
-- Tarball: uncompressed `<name>.tar` at `<S3_DATASETS_BUCKET>/<name>.tar`. Staged to `<RUNNER_LOCAL_DATASETS_ROOT>/datasets/vslam/<name>/` and mounted read-only into the eval container at `/datasets`. An ETag file skips re-download when the cache is current.
+- `DATASETS` in `tools/python_tools/cuvslam_tools/dataset_registry.py` is the single source of truth. A `DatasetSpec` holds the ID, the preparation module, and its `EvalSpec` records; an `EvalSpec` holds the reporter config filename, the `cuvslam_app` flags, suite membership, and gating. Provisionable means the dataset is present; eval-enabled means it has at least one `EvalSpec`. KITTI and EuRoC are eval-enabled; `tum` and `tartan` are provisionable only.
+- The module is standard library only and imports converters lazily, so shell wrappers call it with `PYTHONPATH=tools/python_tools` inside `cuvslam-ci:local` before anything is installed. `datasets_config.sh` wraps it as `dataset_registry`; `run_eval.sh` defines its own shim because the S3 variables `datasets_config.sh` requires are absent in the eval container.
+- Subcommands: `validate`, `list [--eval] [--suite]`, `eval-records` (tab-separated `id`, KPI prefix, config path, flags), `prepare-module`, `prepare --root-file`, `verify-staged --root`.
+- Derived, never declared: `<id>.tar`, the staged directory, the `/sequences` mount, and the KPI prefix (first hyphen-delimited token of the config filename, upper-cased). Validation rejects two records that derive the same prefix and `--odometry_mode`.
+- Tarball: uncompressed `<id>.tar` at `<S3_DATASETS_BUCKET>/<id>.tar`, whose root is the directory `prepare()` returned. Staged to `<RUNNER_LOCAL_DATASETS_ROOT>/datasets/vslam/<id>/` and mounted read-only into the eval container at `/datasets`. An ETag file skips re-download when the cache is current. After extraction, `verify-staged` checks the shipped config's `dataset_folder` equals `<id>/`.
 
 ## KPI outputs
 

--- a/scripts/check_eval_prerequisites.sh
+++ b/scripts/check_eval_prerequisites.sh
@@ -23,13 +23,13 @@ if [ "${GITHUB_ACTIONS:-}" = "true" ] && ! $have_aws; then
 fi
 
 cache_ok=true
-for name in "${EVAL_DATASET_NAMES[@]}"; do
+while read -r name; do
   dest="$LOCAL_DATASETS_DIR/$name"
   if [ ! -d "$dest" ] || [ -z "$(find "$dest" -type f ! -name '.s3_etag' -print -quit 2>/dev/null)" ]; then
     cache_ok=false
     break
   fi
-done
+done < <(dataset_registry list --eval)
 
 if $have_aws; then
   echo "Eval prerequisites OK (S3 tarball staging; KPI history under $RUNNER_STORAGE_ROOT)"

--- a/scripts/check_eval_prerequisites.sh
+++ b/scripts/check_eval_prerequisites.sh
@@ -22,6 +22,15 @@ if [ "${GITHUB_ACTIONS:-}" = "true" ] && ! $have_aws; then
   exit 1
 fi
 
+dataset_registry validate
+
+# Captured rather than piped into the loop: a failing or empty listing would
+# otherwise skip the body and leave cache_ok true, reporting success.
+if ! eval_datasets="$(dataset_registry list --eval)" || [ -z "$eval_datasets" ]; then
+  echo "Error: the dataset registry lists no evaluation datasets." >&2
+  exit 1
+fi
+
 cache_ok=true
 while read -r name; do
   dest="$LOCAL_DATASETS_DIR/$name"
@@ -29,7 +38,7 @@ while read -r name; do
     cache_ok=false
     break
   fi
-done < <(dataset_registry list --eval)
+done <<< "$eval_datasets"
 
 if $have_aws; then
   echo "Eval prerequisites OK (S3 tarball staging; KPI history under $RUNNER_STORAGE_ROOT)"

--- a/scripts/datasets_config.sh
+++ b/scripts/datasets_config.sh
@@ -1,30 +1,15 @@
 S3_DATASETS_BUCKET="${S3_DATASETS_BUCKET:?Set repository variable S3_DATASETS_BUCKET to the dataset tarball location, e.g. s3://your-bucket/datasets/vslam}"
 AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:?Set repository variable AWS_DEFAULT_REGION, e.g. us-west-2}"
 
-PROVISIONABLE_DATASETS=(kitti euroc tum tartan)
+# Dataset names, evaluation records, and the archive layout live in
+# tools/python_tools/cuvslam_tools/dataset_registry.py. That module is standard
+# library only and imports converter code lazily, so it runs here with
+# PYTHONPATH alone, before anything is installed in the image.
+CUVSLAM_REPO_ROOT="${CUVSLAM_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}"
 
-EVAL_DATASET_NAMES=(
-  kitti
-  euroc
-)
-
-is_provisionable_dataset() {
-  local name="$1" d
-  for d in "${PROVISIONABLE_DATASETS[@]}"; do
-    [ "$d" = "$name" ] && return 0
-  done
-  return 1
-}
-
-dataset_upload_subdir() {
-  is_provisionable_dataset "$1" || {
-    echo "Error: unknown dataset '$1' (expected: ${PROVISIONABLE_DATASETS[*]})" >&2
-    return 1
-  }
-  case "$1" in
-    kitti) echo "" ;;
-    *)     echo "$1" ;;
-  esac
+dataset_registry() {
+  PYTHONPATH="$CUVSLAM_REPO_ROOT/tools/python_tools${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 -m cuvslam_tools.dataset_registry "$@"
 }
 
 s3_tarball_uri() {

--- a/scripts/provision_dataset.sh
+++ b/scripts/provision_dataset.sh
@@ -2,12 +2,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 source "$SCRIPT_DIR/datasets_config.sh"
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <dataset>" >&2
-  echo "  Datasets: ${PROVISIONABLE_DATASETS[*]}" >&2
+  echo "  Datasets: $(dataset_registry list | tr '\n' ' ')" >&2
   exit 1
 fi
 
@@ -17,10 +16,7 @@ export AWS_DEFAULT_REGION
 FORCE_DOWNLOAD="${FORCE_DOWNLOAD:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 
-if ! is_provisionable_dataset "$DATASET"; then
-  echo "Error: '$DATASET' is not a provisionable dataset (expected: ${PROVISIONABLE_DATASETS[*]})." >&2
-  exit 1
-fi
+dataset_registry validate --dataset "$DATASET"
 
 if [ "$DRY_RUN" != "true" ] && ! command -v aws >/dev/null 2>&1; then
   echo "Error: aws CLI not found. This script runs inside the cuvslam-ci:local image." >&2
@@ -51,19 +47,8 @@ esac
 raw_dir="$WORK_DIR/raw"
 converted_dir="$WORK_DIR/converted"
 tarball="$WORK_DIR/${DATASET}.tar"
+root_file="$WORK_DIR/archive_root"
 s3_tarball="$(s3_tarball_uri "$DATASET")"
-
-upload_subdir="$(dataset_upload_subdir "$DATASET")"
-upload_src="$converted_dir${upload_subdir:+/$upload_subdir}"
-
-PYTHON_TOOLS_DIR="$REPO_ROOT/tools/python_tools"
-prepare_module="cuvslam_tools.dataset_preparation.${DATASET}.prepare"
-prepare_module_file="$PYTHON_TOOLS_DIR/${prepare_module//.//}.py"
-
-if [ ! -f "$prepare_module_file" ]; then
-  echo "Error: dataset preparation module not found: $prepare_module" >&2
-  exit 1
-fi
 
 if [ "$DRY_RUN" != "true" ]; then
   echo "=== Verifying AWS credentials for S3 upload ==="
@@ -82,14 +67,24 @@ if [ "$DRY_RUN" != "true" ]; then
   echo "AWS credentials OK ($caller_arn)"
 fi
 
-rm -rf "$raw_dir" "$converted_dir" "$tarball"
+rm -rf "$raw_dir" "$converted_dir" "$tarball" "$root_file"
 mkdir -p "$raw_dir" "$converted_dir"
 
-echo "=== Preparing $DATASET with $prepare_module ==="
-PYTHONPATH="$PYTHON_TOOLS_DIR${PYTHONPATH:+:$PYTHONPATH}" python3 -m "$prepare_module" \
+echo "=== Preparing $DATASET with $(dataset_registry prepare-module "$DATASET") ==="
+# prepare() returns the directory to archive, so the tar root is always the
+# dataset root and no per-dataset subdirectory mapping is needed here.
+dataset_registry prepare "$DATASET" \
   --raw-dir "$raw_dir" \
   --output-dir "$converted_dir" \
+  --root-file "$root_file" \
   "${download_args[@]}"
+
+upload_src="$(cat "$root_file")"
+case "$upload_src" in
+  "$WORK_DIR"/*) : ;;
+  *) echo "Error: $DATASET prepare() returned '$upload_src', outside the work dir." >&2; exit 1 ;;
+esac
+echo "Archive root: $upload_src"
 
 file_count="$(find "$upload_src" -type f | wc -l)"
 if [ "$file_count" -eq 0 ]; then

--- a/scripts/run_eval.sh
+++ b/scripts/run_eval.sh
@@ -34,15 +34,25 @@ echo "=== Installing cuvslam tools ==="
   pip install "${python_tools_install_src}[pdf]"
 )
 
-DATASETS=(
-  "KITTI|kitti|kitti|kitti/kitti-vio_slam_gt.cfg|--odometry_mode=multicamera --rectified_stereo_camera=true --async_sba=false --multicam_mode=moderate --use_segments"
-  # "TARTAN|tartanair|tartanV1hard_selected|tartanair/tartan-osmo-vo_slam.cfg|--odometry_mode=multicamera --rectified_stereo_camera=true --async_sba=false --multicam_mode=moderate --use_segments"
-  # "M3ED_SPOT|m3ed_spot|m3ed_spot|m3ed_spot/m3ed_spot.cfg|--odometry_mode=multicamera --rectified_stereo_camera=false --async_sba=false --multicam_mode=moderate --use_segments"
-  "EUROC|euroc|euroc|euroc/euroc-vio_slam.cfg|--odometry_mode=inertial --rectified_stereo_camera=false --async_sba=false --multicam_mode=moderate --use_segments"
-  # "TUM_RGBD|tum-rgbd|tum_rgbd_edex|tum-rgbd/tum.cfg|--odometry_mode=rgbd --async_sba=false --use_segments"
-  # "AR_TABLE|ar_table|ar_table_edex|ar_table/ar_table.cfg|--odometry_mode=rgbd --async_sba=false --use_segments"
-  # "ICL_NUIM|icl-nuim|icl_nuim_edex|icl_nuim_edex/icl-nuim.cfg|--odometry_mode=rgbd --async_sba=false --use_segments"
-)
+# Evaluation records come from the dataset registry, not a local array. The
+# registry is standard library only, so PYTHONPATH is enough here; this runs
+# before the tools package is installed below.
+dataset_registry() {
+  PYTHONPATH="/cuvslam/tools/python_tools${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 -m cuvslam_tools.dataset_registry "$@"
+}
+
+dataset_registry validate
+
+DATASETS=()
+while IFS= read -r record; do
+  DATASETS+=("$record")
+done < <(dataset_registry eval-records)
+
+if [ "${#DATASETS[@]}" -eq 0 ]; then
+  echo "Error: the dataset registry lists no evaluation records." >&2
+  exit 1
+fi
 
 echo "=== Datasets present under $DATASETS_ROOT ==="
 if [ -d "$DATASETS_ROOT" ]; then
@@ -55,9 +65,9 @@ fi
 requested=()
 missing=()
 for record in "${DATASETS[@]}"; do
-  IFS='|' read -r label _link subdir _cfg _flags <<< "$record"
+  IFS=$'\t' read -r name label _cfg _flags <<< "$record"
   requested+=("$label")
-  [ -d "$DATASETS_ROOT/$subdir" ] || missing+=("$label -> $DATASETS_ROOT/$subdir")
+  [ -d "$DATASETS_ROOT/$name" ] || missing+=("$label -> $DATASETS_ROOT/$name")
 done
 
 echo "=== Requested datasets (${#requested[@]}): ${requested[*]} ==="
@@ -77,9 +87,11 @@ export CUVSLAM_OUTPUT="$EVAL_STATS"
 cd /cuvslam/tools/cuvslam_app
 
 for record in "${DATASETS[@]}"; do
-  IFS='|' read -r label link_name subdir test_config app_flags <<< "$record"
+  IFS=$'\t' read -r name label test_config app_flags <<< "$record"
 
-  ln -sfn "$DATASETS_ROOT/$subdir" "/sequences/$link_name"
+  # The mount name equals the dataset ID, which is also the "dataset_folder"
+  # recorded in the shipped reporter config.
+  ln -sfn "$DATASETS_ROOT/$name" "/sequences/$name"
 
   echo "=== Running cuVSLAM eval on $label ($test_config) ==="
   # shellcheck disable=SC2086

--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -116,8 +116,14 @@ stage_one() {
   report_staging_profile "$name" "$remote_bytes" "$stream_seconds" "$file_count"
 }
 
-for name in "${EVAL_DATASET_NAMES[@]}"; do
+# Fails in seconds on a registry fault, rather than after a download.
+dataset_registry validate
+
+while read -r name; do
   stage_one "$name"
-done
+  # The reporter resolves sequences through the "dataset_folder" recorded in the
+  # shipped config, which must agree with the mount this script just created.
+  dataset_registry verify-staged "$name" --root "$LOCAL_DATASETS_DIR/$name"
+done < <(dataset_registry list --eval)
 
 echo "Dataset staging complete: $LOCAL_DATASETS_DIR"

--- a/scripts/stage_eval_datasets.sh
+++ b/scripts/stage_eval_datasets.sh
@@ -119,11 +119,18 @@ stage_one() {
 # Fails in seconds on a registry fault, rather than after a download.
 dataset_registry validate
 
+# Captured rather than piped into the loop, so an empty listing is an error
+# instead of a staging run that silently does nothing.
+if ! eval_datasets="$(dataset_registry list --eval)" || [ -z "$eval_datasets" ]; then
+  echo "Error: the dataset registry lists no evaluation datasets." >&2
+  exit 1
+fi
+
 while read -r name; do
   stage_one "$name"
   # The reporter resolves sequences through the "dataset_folder" recorded in the
   # shipped config, which must agree with the mount this script just created.
   dataset_registry verify-staged "$name" --root "$LOCAL_DATASETS_DIR/$name"
-done < <(dataset_registry list --eval)
+done <<< "$eval_datasets"
 
 echo "Dataset staging complete: $LOCAL_DATASETS_DIR"

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/tum/prepare.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/tum/prepare.py
@@ -71,8 +71,8 @@ def prepare(
 ) -> Path:
     """Download and lay out the TUM RGB-D sequence, and return the prepared root.
 
-    Returns the raw directory when ``download_only`` is set, otherwise the sequence
-    directory holding the extracted data and the rig calibration.
+    Returns the raw directory when ``download_only`` is set, otherwise the dataset
+    root holding the extracted sequence and its rig calibration.
     """
     raw_dir = resolve_raw_dir(raw_dir, DATASET_NAME)
     output_dir = resolve_output_dir(output_dir)
@@ -105,8 +105,11 @@ def prepare(
     shutil.copyfile(dataset_file(__file__, RIG_FILE), sequence_dir / RIG_FILE)
 
     print()
-    print(f"done — dataset ready at {sequence_dir}")
-    return sequence_dir
+    print(f"done — sequence ready at {sequence_dir}")
+    # The dataset root is returned, not the sequence: provisioning archives this
+    # directory, and the reporter expects sequence folders directly beneath the
+    # dataset mount.
+    return dataset_dir
 
 
 def main(argv: Optional[List[str]] = None) -> int:

--- a/tools/python_tools/cuvslam_tools/dataset_registry.py
+++ b/tools/python_tools/cuvslam_tools/dataset_registry.py
@@ -1,0 +1,372 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+"""Single source of truth for the evaluation datasets and their reporter runs.
+
+One dataset ID is the only name written down. The preparation module, the private
+tarball, the staged directory, and the ``/sequences`` mount all derive from it,
+and ``prepare()`` returns the directory that provisioning archives, so the tar
+root is always the dataset root.
+
+An evaluation is identified by its reporter config filename. The KPI prefix is
+derived from that name rather than declared, matching what
+``scripts/cuvslam_kpi_report.py`` computes from the reporter's output directory:
+the first hyphen-delimited token, upper-cased. Keep underscores inside a prefix
+and use a hyphen only to terminate it, so ``tartan_flaky-vo_slam.cfg`` yields
+``TARTAN_FLAKY`` while ``tartan-flaky-vo_slam.cfg`` would collide with
+``TARTAN``.
+
+This module is standard library only and imports preparation code lazily, so
+``python3 -m cuvslam_tools.dataset_registry`` works with ``PYTHONPATH`` alone
+inside the CI image, before anything is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Sequence
+
+SUITES = ("smoke", "full")
+GATING_POLICIES = ("hard", "soft", "informational")
+
+# Values cuvslam_app accepts for --odometry_mode. cuvslam_kpi_report.py maps each
+# to a distinct KPI type, and anything unrecognized there falls back to STEREO,
+# so an unknown mode here would silently mislabel a KPI key.
+ODOMETRY_MODES = ("multicamera", "mono", "inertial", "rgbd")
+
+_DATASET_ID = re.compile(r"^[a-z0-9_]+$")
+_KPI_PREFIX = re.compile(r"^[A-Z0-9_]+$")
+
+
+class RegistryError(ValueError):
+    """Raised when the registry, or a staged dataset, violates the contract."""
+
+
+@dataclass(frozen=True)
+class EvalSpec:
+    """One reporter run: which config, which flags, which suites, how it gates."""
+
+    config: str
+    args: tuple[str, ...]
+    suites: frozenset[str]
+    gating: str = "soft"
+
+    @property
+    def kpi_prefix(self) -> str:
+        """Dataset prefix the KPI collector will derive from this config name."""
+        return Path(self.config).stem.split("-")[0].upper()
+
+    @property
+    def odometry_mode(self) -> str:
+        """Value of the --odometry_mode flag, which decides the KPI type."""
+        for argument in self.args:
+            if argument.startswith("--odometry_mode="):
+                return argument.split("=", 1)[1]
+        return ""
+
+
+@dataclass(frozen=True)
+class DatasetSpec:
+    """One dataset: how to prepare it, and the reporter runs it feeds."""
+
+    dataset_id: str
+    prepare_module: str
+    evals: tuple[EvalSpec, ...] = field(default_factory=tuple)
+
+    @property
+    def archive_name(self) -> str:
+        """Private tarball basename."""
+        return f"{self.dataset_id}.tar"
+
+    @property
+    def mount_name(self) -> str:
+        """Staged directory and /sequences mount name.
+
+        Equal to the dataset ID by contract, and must match the "dataset_folder"
+        value the converter writes into each reporter config.
+        """
+        return self.dataset_id
+
+    @property
+    def is_eval_enabled(self) -> bool:
+        return bool(self.evals)
+
+    def load_prepare(self):
+        """Import the preparation module and return its ``prepare`` callable.
+
+        Deferred so listing or validating the registry never pulls in a
+        converter's numerical dependencies.
+        """
+        module = importlib.import_module(self.prepare_module)
+        prepare = getattr(module, "prepare", None)
+        if not callable(prepare):
+            raise RegistryError(f"{self.prepare_module} does not expose a callable prepare()")
+        return prepare
+
+
+def _stereo_args(*extra: str) -> tuple[str, ...]:
+    return ("--odometry_mode=multicamera", *extra, "--async_sba=false", "--multicam_mode=moderate", "--use_segments")
+
+
+DATASETS: dict[str, DatasetSpec] = {
+    "kitti": DatasetSpec(
+        dataset_id="kitti",
+        prepare_module="cuvslam_tools.dataset_preparation.kitti.prepare",
+        evals=(
+            EvalSpec(
+                config="kitti-vio_slam_gt.cfg",
+                args=_stereo_args("--rectified_stereo_camera=true"),
+                suites=frozenset(SUITES),
+            ),
+        ),
+    ),
+    "euroc": DatasetSpec(
+        dataset_id="euroc",
+        prepare_module="cuvslam_tools.dataset_preparation.euroc.prepare",
+        evals=(
+            EvalSpec(
+                config="euroc-vio_slam.cfg",
+                args=(
+                    "--odometry_mode=inertial",
+                    "--rectified_stereo_camera=false",
+                    "--async_sba=false",
+                    "--multicam_mode=moderate",
+                    "--use_segments",
+                ),
+                suites=frozenset(SUITES),
+            ),
+        ),
+    ),
+    # Provisionable but not yet evaluated: no reporter configs are produced and no
+    # validated tarball exists. Adding an EvalSpec is what enables a dataset.
+    "tum": DatasetSpec(
+        dataset_id="tum",
+        prepare_module="cuvslam_tools.dataset_preparation.tum.prepare",
+    ),
+    "tartan": DatasetSpec(
+        dataset_id="tartan",
+        prepare_module="cuvslam_tools.dataset_preparation.tartan.prepare",
+    ),
+}
+
+
+def dataset(dataset_id: str) -> DatasetSpec:
+    """Return one dataset spec, or raise naming the known IDs."""
+    try:
+        return DATASETS[dataset_id]
+    except KeyError:
+        known = ", ".join(sorted(DATASETS))
+        raise RegistryError(f"unknown dataset '{dataset_id}' (known: {known})") from None
+
+
+def provisionable_datasets() -> list[DatasetSpec]:
+    """All datasets, in declaration order, which is also evaluation order."""
+    return list(DATASETS.values())
+
+
+def eval_datasets(suite: str | None = None) -> list[DatasetSpec]:
+    """Datasets with at least one reporter run, optionally filtered by suite."""
+    return [spec for spec in DATASETS.values() if eval_records(spec, suite)]
+
+
+def eval_records(spec: DatasetSpec, suite: str | None = None) -> list[EvalSpec]:
+    if suite is None:
+        return list(spec.evals)
+    if suite not in SUITES:
+        raise RegistryError(f"unknown suite '{suite}' (known: {', '.join(SUITES)})")
+    return [record for record in spec.evals if suite in record.suites]
+
+
+def reporter_config_path(spec: DatasetSpec, record: EvalSpec) -> str:
+    """Reporter config path relative to CUVSLAM_DATASETS."""
+    return f"{spec.mount_name}/{record.config}"
+
+
+def _validate_eval(spec: DatasetSpec, record: EvalSpec) -> None:
+    where = f"{spec.dataset_id} eval '{record.config}'"
+    if not record.config or Path(record.config).name != record.config:
+        raise RegistryError(f"{where}: config must be a bare filename at the dataset root")
+    if not record.config.endswith(".cfg"):
+        raise RegistryError(f"{where}: config must end with .cfg")
+    if not _KPI_PREFIX.match(record.kpi_prefix):
+        raise RegistryError(
+            f"{where}: derived KPI prefix '{record.kpi_prefix}' is not upper-case alphanumeric; "
+            "keep underscores inside the prefix and use a hyphen only to terminate it"
+        )
+    if not record.args or not all(isinstance(a, str) and a.startswith("--") for a in record.args):
+        raise RegistryError(f"{where}: args must be a non-empty tuple of --flag strings")
+    if record.odometry_mode not in ODOMETRY_MODES:
+        raise RegistryError(
+            f"{where}: --odometry_mode must be one of {', '.join(ODOMETRY_MODES)}; "
+            "an unrecognized mode silently becomes a STEREO KPI type"
+        )
+    if not record.suites:
+        raise RegistryError(f"{where}: must belong to at least one suite")
+    unknown = sorted(record.suites - set(SUITES))
+    if unknown:
+        raise RegistryError(f"{where}: unknown suite(s) {', '.join(unknown)}")
+    if record.gating not in GATING_POLICIES:
+        raise RegistryError(f"{where}: gating must be one of {', '.join(GATING_POLICIES)}")
+
+
+def validate(dataset_ids: Iterable[str] | None = None) -> None:
+    """Check the whole registry, or the named subset, and raise on the first fault."""
+    specs = [dataset(name) for name in dataset_ids] if dataset_ids else provisionable_datasets()
+
+    for key, spec in DATASETS.items():
+        if key != spec.dataset_id:
+            raise RegistryError(f"registry key '{key}' does not match dataset_id '{spec.dataset_id}'")
+
+    seen_keys: dict[tuple[str, str], str] = {}
+    for spec in specs:
+        if not _DATASET_ID.match(spec.dataset_id):
+            raise RegistryError(f"dataset id '{spec.dataset_id}' must be lower-case alphanumeric or underscore")
+        # find_spec raises rather than returning None when a parent package is
+        # missing, so both outcomes mean the same thing here.
+        try:
+            found = importlib.util.find_spec(spec.prepare_module) is not None
+        except (ImportError, ValueError):
+            found = False
+        if not found:
+            raise RegistryError(f"{spec.dataset_id}: preparation module not found: {spec.prepare_module}")
+        for record in spec.evals:
+            _validate_eval(spec, record)
+            key = (record.kpi_prefix, record.odometry_mode)
+            if key in seen_keys:
+                raise RegistryError(
+                    f"{spec.dataset_id} eval '{record.config}' derives the same KPI identity as "
+                    f"'{seen_keys[key]}': prefix {key[0]} with mode {key[1]}. One would silently "
+                    "overwrite the other in the KPI report."
+                )
+            seen_keys[key] = f"{spec.dataset_id}/{record.config}"
+
+
+def verify_staged(spec: DatasetSpec, root: Path) -> None:
+    """Check that a staged dataset matches the registry's mount name.
+
+    Each reporter config declares the directory it expects under
+    CUVSLAM_DATASETS. If that disagrees with the dataset ID, the reporter looks
+    for sequences in a directory staging never created.
+    """
+    expected = f"{spec.mount_name}/"
+    for record in spec.evals:
+        config_path = root / record.config
+        if not config_path.is_file():
+            raise RegistryError(f"{spec.dataset_id}: staged config not found: {config_path}")
+        try:
+            declared = json.loads(config_path.read_text(encoding="utf-8")).get("dataset_folder")
+        except json.JSONDecodeError as exc:
+            raise RegistryError(f"{spec.dataset_id}: {config_path} is not valid JSON: {exc}") from exc
+        if declared != expected:
+            raise RegistryError(
+                f"{spec.dataset_id}: {record.config} declares dataset_folder {declared!r}, "
+                f"expected {expected!r}. Regenerate the dataset or rename it in the registry."
+            )
+
+
+def _print_records(suite: str | None) -> None:
+    for spec in eval_datasets(suite):
+        for record in eval_records(spec, suite):
+            print(
+                "\t".join(
+                    (
+                        spec.dataset_id,
+                        record.kpi_prefix,
+                        reporter_config_path(spec, record),
+                        " ".join(record.args),
+                    )
+                )
+            )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="cuvslam_tools.dataset_registry",
+        description="Inspect and validate the cuVSLAM evaluation dataset registry.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate", help="Check the registry contract.")
+    validate_parser.add_argument("--dataset", action="append", default=None, help="Limit to one dataset; repeatable.")
+
+    list_parser = subparsers.add_parser("list", help="Print dataset IDs, one per line.")
+    list_parser.add_argument("--eval", action="store_true", help="Only datasets with reporter runs.")
+    list_parser.add_argument("--suite", default=None, choices=SUITES, help="Filter reporter runs by suite.")
+
+    records_parser = subparsers.add_parser(
+        "eval-records", help="Print id, KPI prefix, config path, and flags as tab-separated fields."
+    )
+    records_parser.add_argument("--suite", default=None, choices=SUITES)
+
+    module_parser = subparsers.add_parser("prepare-module", help="Print a dataset's preparation module path.")
+    module_parser.add_argument("dataset")
+
+    prepare_parser = subparsers.add_parser("prepare", help="Run a dataset's prepare() and report the archive root.")
+    prepare_parser.add_argument("dataset")
+    prepare_parser.add_argument("--raw-dir", type=Path, required=True)
+    prepare_parser.add_argument("--output-dir", type=Path, required=True)
+    prepare_parser.add_argument("--force-download", action="store_true")
+    prepare_parser.add_argument(
+        "--root-file",
+        type=Path,
+        required=True,
+        help="File to write the archive root to, keeping stdout free for converter logs.",
+    )
+
+    staged_parser = subparsers.add_parser("verify-staged", help="Check a staged dataset against the registry.")
+    staged_parser.add_argument("dataset")
+    staged_parser.add_argument("--root", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "validate":
+            validate(args.dataset)
+            scope = ", ".join(args.dataset) if args.dataset else f"{len(DATASETS)} datasets"
+            print(f"dataset registry OK ({scope})")
+        elif args.command == "list":
+            specs = eval_datasets(args.suite) if (args.eval or args.suite) else provisionable_datasets()
+            for spec in specs:
+                print(spec.dataset_id)
+        elif args.command == "eval-records":
+            _print_records(args.suite)
+        elif args.command == "prepare-module":
+            print(dataset(args.dataset).prepare_module)
+        elif args.command == "prepare":
+            spec = dataset(args.dataset)
+            validate([spec.dataset_id])
+            root = spec.load_prepare()(
+                raw_dir=args.raw_dir,
+                output_dir=args.output_dir,
+                force_download=args.force_download,
+            )
+            args.root_file.write_text(f"{Path(root).resolve()}\n", encoding="utf-8")
+        elif args.command == "verify-staged":
+            verify_staged(dataset(args.dataset), args.root)
+            print(f"staged {args.dataset} matches the registry")
+    except RegistryError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/python_tools/cuvslam_tools/dataset_registry.py
+++ b/tools/python_tools/cuvslam_tools/dataset_registry.py
@@ -75,12 +75,19 @@ class EvalSpec:
         return Path(self.config).stem.split("-")[0].upper()
 
     @property
+    def odometry_modes(self) -> tuple[str, ...]:
+        """Every --odometry_mode value in the argument tuple."""
+        return tuple(a.split("=", 1)[1] for a in self.args if a.startswith("--odometry_mode="))
+
+    @property
     def odometry_mode(self) -> str:
-        """Value of the --odometry_mode flag, which decides the KPI type."""
-        for argument in self.args:
-            if argument.startswith("--odometry_mode="):
-                return argument.split("=", 1)[1]
-        return ""
+        """The --odometry_mode value, which decides the KPI type.
+
+        Validation requires exactly one, so a repeated flag cannot make this
+        disagree with the last-wins value cuvslam_app would actually use.
+        """
+        modes = self.odometry_modes
+        return modes[0] if len(modes) == 1 else ""
 
 
 @dataclass(frozen=True)
@@ -213,7 +220,13 @@ def _validate_eval(spec: DatasetSpec, record: EvalSpec) -> None:
         )
     if not record.args or not all(isinstance(a, str) and a.startswith("--") for a in record.args):
         raise RegistryError(f"{where}: args must be a non-empty tuple of --flag strings")
-    if record.odometry_mode not in ODOMETRY_MODES:
+    modes = record.odometry_modes
+    if len(modes) != 1:
+        raise RegistryError(
+            f"{where}: expected exactly one --odometry_mode flag, found {len(modes)}. "
+            "cuvslam_app takes the last value, so a repeat would run a mode the registry did not check"
+        )
+    if modes[0] not in ODOMETRY_MODES:
         raise RegistryError(
             f"{where}: --odometry_mode must be one of {', '.join(ODOMETRY_MODES)}; "
             "an unrecognized mode silently becomes a STEREO KPI type"
@@ -227,15 +240,36 @@ def _validate_eval(spec: DatasetSpec, record: EvalSpec) -> None:
         raise RegistryError(f"{where}: gating must be one of {', '.join(GATING_POLICIES)}")
 
 
-def validate(dataset_ids: Iterable[str] | None = None) -> None:
-    """Check the whole registry, or the named subset, and raise on the first fault."""
-    specs = [dataset(name) for name in dataset_ids] if dataset_ids else provisionable_datasets()
+def _validate_kpi_identities() -> None:
+    """Reject two records that would produce the same KPI keys.
 
+    Always spans the whole registry: a collision is a property of a pair, so
+    checking one dataset in isolation cannot see it.
+    """
+    seen: dict[tuple[str, str], str] = {}
+    for spec in DATASETS.values():
+        for record in spec.evals:
+            key = (record.kpi_prefix, record.odometry_mode)
+            origin = f"{spec.dataset_id}/{record.config}"
+            if key in seen:
+                raise RegistryError(
+                    f"{origin} derives the same KPI identity as '{seen[key]}': prefix {key[0]} "
+                    f"with mode {key[1]}. One would silently overwrite the other in the KPI report."
+                )
+            seen[key] = origin
+
+
+def validate(dataset_ids: Iterable[str] | None = None) -> None:
+    """Check the registry and raise on the first fault.
+
+    ``dataset_ids`` narrows the per-dataset checks; KPI identities are compared
+    across every dataset regardless.
+    """
     for key, spec in DATASETS.items():
         if key != spec.dataset_id:
             raise RegistryError(f"registry key '{key}' does not match dataset_id '{spec.dataset_id}'")
 
-    seen_keys: dict[tuple[str, str], str] = {}
+    specs = [dataset(name) for name in dataset_ids] if dataset_ids else provisionable_datasets()
     for spec in specs:
         if not _DATASET_ID.match(spec.dataset_id):
             raise RegistryError(f"dataset id '{spec.dataset_id}' must be lower-case alphanumeric or underscore")
@@ -249,14 +283,8 @@ def validate(dataset_ids: Iterable[str] | None = None) -> None:
             raise RegistryError(f"{spec.dataset_id}: preparation module not found: {spec.prepare_module}")
         for record in spec.evals:
             _validate_eval(spec, record)
-            key = (record.kpi_prefix, record.odometry_mode)
-            if key in seen_keys:
-                raise RegistryError(
-                    f"{spec.dataset_id} eval '{record.config}' derives the same KPI identity as "
-                    f"'{seen_keys[key]}': prefix {key[0]} with mode {key[1]}. One would silently "
-                    "overwrite the other in the KPI report."
-                )
-            seen_keys[key] = f"{spec.dataset_id}/{record.config}"
+
+    _validate_kpi_identities()
 
 
 def verify_staged(spec: DatasetSpec, root: Path) -> None:
@@ -272,9 +300,14 @@ def verify_staged(spec: DatasetSpec, root: Path) -> None:
         if not config_path.is_file():
             raise RegistryError(f"{spec.dataset_id}: staged config not found: {config_path}")
         try:
-            declared = json.loads(config_path.read_text(encoding="utf-8")).get("dataset_folder")
+            config = json.loads(config_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
             raise RegistryError(f"{spec.dataset_id}: {config_path} is not valid JSON: {exc}") from exc
+        if not isinstance(config, dict):
+            raise RegistryError(
+                f"{spec.dataset_id}: {config_path} must hold a JSON object, got {type(config).__name__}"
+            )
+        declared = config.get("dataset_folder")
         if declared != expected:
             raise RegistryError(
                 f"{spec.dataset_id}: {record.config} declares dataset_folder {declared!r}, "

--- a/tools/python_tools/cuvslam_tools/tests/test_dataset_preparation.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_dataset_preparation.py
@@ -23,10 +23,10 @@ from contextlib import redirect_stdout
 from pathlib import Path
 from unittest import mock
 
+from cuvslam_tools import dataset_registry
 from cuvslam_tools.dataset_preparation import common
 
-# Kept in sync with PROVISIONABLE_DATASETS in scripts/datasets_config.sh.
-DATASETS = ("kitti", "euroc", "tum", "tartan")
+DATASETS = tuple(spec.dataset_id for spec in dataset_registry.provisionable_datasets())
 
 PREPARATION_ROOT = Path(common.__file__).resolve().parent
 

--- a/tools/python_tools/cuvslam_tools/tests/test_dataset_registry.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_dataset_registry.py
@@ -150,6 +150,35 @@ class TestValidationFailures(unittest.TestCase):
         with self.assertRaisesRegex(RegistryError, "odometry_mode must be one of"):
             self._validate({"kitti": spec})
 
+    def test_repeated_odometry_mode_fails(self):
+        # cuvslam_app takes the last value, so a repeat could run an unchecked mode.
+        record = stereo_eval(args=("--odometry_mode=multicamera", "--odometry_mode=rgbd"))
+        with self.assertRaisesRegex(RegistryError, "exactly one --odometry_mode flag, found 2"):
+            self._validate({"kitti": DatasetSpec("kitti", KITTI_PREPARE, (record,))})
+
+    def test_missing_odometry_mode_fails(self):
+        record = stereo_eval(args=("--use_segments",))
+        with self.assertRaisesRegex(RegistryError, "exactly one --odometry_mode flag, found 0"):
+            self._validate({"kitti": DatasetSpec("kitti", KITTI_PREPARE, (record,))})
+
+    def test_collision_across_datasets_is_caught_when_scoped_to_one(self):
+        # A collision belongs to the pair, so narrowing to one dataset must not hide it.
+        datasets = {
+            "kitti": DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(config="tartan-a.cfg"),)),
+            "tartan": DatasetSpec(
+                "tartan",
+                "cuvslam_tools.dataset_preparation.tartan.prepare",
+                (stereo_eval(config="tartan-b.cfg"),),
+            ),
+        }
+        original = dataset_registry.DATASETS
+        dataset_registry.DATASETS = datasets
+        try:
+            with self.assertRaisesRegex(RegistryError, "same KPI identity"):
+                dataset_registry.validate(["kitti"])
+        finally:
+            dataset_registry.DATASETS = original
+
     def test_malformed_argument_tuple_fails(self):
         spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(args=("odometry_mode=multicamera",)),))
         with self.assertRaisesRegex(RegistryError, "non-empty tuple of --flag"):
@@ -228,6 +257,13 @@ class TestVerifyStaged(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             (Path(root) / "kitti-vio_slam_gt.cfg").write_text("{not json", encoding="utf-8")
             with self.assertRaisesRegex(RegistryError, "not valid JSON"):
+                dataset_registry.verify_staged(spec, Path(root))
+
+    def test_json_that_is_not_an_object_fails(self):
+        spec = dataset_registry.dataset("kitti")
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "kitti-vio_slam_gt.cfg").write_text("[]", encoding="utf-8")
+            with self.assertRaisesRegex(RegistryError, "must hold a JSON object, got list"):
                 dataset_registry.verify_staged(spec, Path(root))
 
 

--- a/tools/python_tools/cuvslam_tools/tests/test_dataset_registry.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_dataset_registry.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from cuvslam_tools import dataset_registry
+from cuvslam_tools.dataset_registry import DatasetSpec, EvalSpec, RegistryError
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+KITTI_PREPARE = "cuvslam_tools.dataset_preparation.kitti.prepare"
+
+
+def stereo_eval(config="kitti-vio_slam_gt.cfg", mode="multicamera", **overrides):
+    fields = {
+        "config": config,
+        "args": (f"--odometry_mode={mode}", "--use_segments"),
+        "suites": frozenset(dataset_registry.SUITES),
+    }
+    fields.update(overrides)
+    return EvalSpec(**fields)
+
+
+class TestShippedRegistry(unittest.TestCase):
+    def test_shipped_registry_validates(self):
+        dataset_registry.validate()
+
+    def test_kitti_and_euroc_records_match_the_previous_shell_records(self):
+        # Guards the refactor: these are the label, config path, and flags that
+        # scripts/run_eval.sh carried as pipe-delimited records, in the same order.
+        expected = [
+            (
+                "kitti",
+                "KITTI",
+                "kitti/kitti-vio_slam_gt.cfg",
+                "--odometry_mode=multicamera --rectified_stereo_camera=true "
+                "--async_sba=false --multicam_mode=moderate --use_segments",
+            ),
+            (
+                "euroc",
+                "EUROC",
+                "euroc/euroc-vio_slam.cfg",
+                "--odometry_mode=inertial --rectified_stereo_camera=false "
+                "--async_sba=false --multicam_mode=moderate --use_segments",
+            ),
+        ]
+
+        actual = [
+            (
+                spec.dataset_id,
+                record.kpi_prefix,
+                dataset_registry.reporter_config_path(spec, record),
+                " ".join(record.args),
+            )
+            for spec in dataset_registry.eval_datasets()
+            for record in dataset_registry.eval_records(spec)
+        ]
+
+        self.assertEqual(actual, expected)
+
+    def test_archive_and_mount_derive_from_the_dataset_id(self):
+        for spec in dataset_registry.provisionable_datasets():
+            self.assertEqual(spec.archive_name, f"{spec.dataset_id}.tar")
+            self.assertEqual(spec.mount_name, spec.dataset_id)
+
+    def test_only_kitti_and_euroc_are_eval_enabled(self):
+        enabled = [spec.dataset_id for spec in dataset_registry.eval_datasets()]
+        self.assertEqual(enabled, ["kitti", "euroc"])
+
+    def test_listing_the_registry_imports_no_converter_dependencies(self):
+        # In a subprocess, because sibling test modules import converters and
+        # would otherwise leave their dependencies in sys.modules.
+        probe = (
+            "import sys; from cuvslam_tools import dataset_registry as r; r.validate();"
+            "[print(m) for m in ('numpy', 'cv2', 'scipy', 'PIL', 'h5py', 'yaml') if m in sys.modules]"
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", probe],
+            cwd=REPO_ROOT,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "tools" / "python_tools")},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(completed.stdout.strip(), "", f"validating the registry imported {completed.stdout.split()}")
+
+    def test_registry_cli_runs_without_the_package_installed(self):
+        # CI shell wrappers call the module with PYTHONPATH alone, inside an image
+        # where nothing is pip installed.
+        completed = subprocess.run(
+            [sys.executable, "-m", "cuvslam_tools.dataset_registry", "eval-records"],
+            cwd=REPO_ROOT,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "tools" / "python_tools")},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        rows = [line.split("\t") for line in completed.stdout.strip().splitlines()]
+        self.assertEqual([row[0] for row in rows], ["kitti", "euroc"])
+        self.assertTrue(all(len(row) == 4 for row in rows), rows)
+
+    def test_every_provisioning_workflow_choice_is_a_registry_dataset(self):
+        workflow = (REPO_ROOT / ".github" / "workflows" / "provision-datasets.yml").read_text(encoding="utf-8")
+        block = re.search(r"options:\n((?:\s+-\s+\S+\n)+)", workflow)
+        self.assertIsNotNone(block, "could not find the dataset choice options block")
+        choices = re.findall(r"-\s+(\S+)", block.group(1))
+        self.assertTrue(choices)
+        for choice in choices:
+            self.assertIn(choice, dataset_registry.DATASETS, f"workflow offers unknown dataset '{choice}'")
+
+    def test_preparation_modules_expose_a_callable_prepare(self):
+        # Imports the converters, so it is the one test that pays that cost.
+        for spec in dataset_registry.provisionable_datasets():
+            self.assertTrue(callable(spec.load_prepare()), spec.dataset_id)
+
+
+class TestValidationFailures(unittest.TestCase):
+    def _validate(self, datasets):
+        original = dataset_registry.DATASETS
+        dataset_registry.DATASETS = datasets
+        try:
+            dataset_registry.validate()
+        finally:
+            dataset_registry.DATASETS = original
+
+    def test_key_must_match_dataset_id(self):
+        with self.assertRaisesRegex(RegistryError, "does not match dataset_id"):
+            self._validate({"kitty": DatasetSpec("kitti", KITTI_PREPARE)})
+
+    def test_dataset_id_must_be_lower_case(self):
+        with self.assertRaisesRegex(RegistryError, "must be lower-case"):
+            self._validate({"KITTI": DatasetSpec("KITTI", KITTI_PREPARE)})
+
+    def test_missing_preparation_module_fails(self):
+        with self.assertRaisesRegex(RegistryError, "preparation module not found"):
+            self._validate({"kitti": DatasetSpec("kitti", "cuvslam_tools.dataset_preparation.nope.prepare")})
+
+    def test_config_must_be_a_bare_filename(self):
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(config="kitti/kitti-vio_slam_gt.cfg"),))
+        with self.assertRaisesRegex(RegistryError, "bare filename"):
+            self._validate({"kitti": spec})
+
+    def test_hyphenated_prefix_is_rejected_before_it_can_collide(self):
+        # tartan-flaky-... would derive TARTAN and overwrite the stable report.
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(config="kitti.txt"),))
+        with self.assertRaisesRegex(RegistryError, "must end with .cfg"):
+            self._validate({"kitti": spec})
+
+    def test_unknown_odometry_mode_fails(self):
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(mode="stereo"),))
+        with self.assertRaisesRegex(RegistryError, "odometry_mode must be one of"):
+            self._validate({"kitti": spec})
+
+    def test_malformed_argument_tuple_fails(self):
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(args=("odometry_mode=multicamera",)),))
+        with self.assertRaisesRegex(RegistryError, "non-empty tuple of --flag"):
+            self._validate({"kitti": spec})
+
+    def test_unknown_suite_fails(self):
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(suites=frozenset({"nightly"})),))
+        with self.assertRaisesRegex(RegistryError, "unknown suite"):
+            self._validate({"kitti": spec})
+
+    def test_empty_suite_membership_fails(self):
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(suites=frozenset()),))
+        with self.assertRaisesRegex(RegistryError, "at least one suite"):
+            self._validate({"kitti": spec})
+
+    def test_unknown_gating_policy_fails(self):
+        spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(gating="blocking"),))
+        with self.assertRaisesRegex(RegistryError, "gating must be one of"):
+            self._validate({"kitti": spec})
+
+    def test_two_evals_deriving_one_kpi_identity_fail(self):
+        # Both configs reduce to the TARTAN prefix with the same mode, so one
+        # would silently replace the other in the KPI report.
+        colliding = DatasetSpec(
+            "tartan",
+            "cuvslam_tools.dataset_preparation.tartan.prepare",
+            (stereo_eval(config="tartan-osmo-vo_slam.cfg"), stereo_eval(config="tartan-flaky-vo_slam.cfg")),
+        )
+        with self.assertRaisesRegex(RegistryError, "same KPI identity"):
+            self._validate({"tartan": colliding})
+
+    def test_underscore_prefix_keeps_the_flaky_report_distinct(self):
+        distinct = DatasetSpec(
+            "tartan",
+            "cuvslam_tools.dataset_preparation.tartan.prepare",
+            (stereo_eval(config="tartan-osmo-vo_slam.cfg"), stereo_eval(config="tartan_flaky-vo_slam.cfg")),
+        )
+        self._validate({"tartan": distinct})
+        self.assertEqual(distinct.evals[0].kpi_prefix, "TARTAN")
+        self.assertEqual(distinct.evals[1].kpi_prefix, "TARTAN_FLAKY")
+
+    def test_unknown_dataset_lookup_lists_known_ids(self):
+        with self.assertRaisesRegex(RegistryError, "known: euroc, kitti, tartan, tum"):
+            dataset_registry.dataset("m3ed_spot")
+
+    def test_unknown_suite_filter_fails(self):
+        with self.assertRaisesRegex(RegistryError, "unknown suite"):
+            dataset_registry.eval_records(dataset_registry.dataset("kitti"), "nightly")
+
+
+class TestVerifyStaged(unittest.TestCase):
+    def _stage(self, root, config, dataset_folder):
+        (Path(root) / config).write_text(json.dumps({"dataset_folder": dataset_folder}), encoding="utf-8")
+
+    def test_matching_dataset_folder_passes(self):
+        spec = dataset_registry.dataset("kitti")
+        with tempfile.TemporaryDirectory() as root:
+            self._stage(root, "kitti-vio_slam_gt.cfg", "kitti/")
+            dataset_registry.verify_staged(spec, Path(root))
+
+    def test_mismatched_dataset_folder_fails(self):
+        spec = dataset_registry.dataset("kitti")
+        with tempfile.TemporaryDirectory() as root:
+            self._stage(root, "kitti-vio_slam_gt.cfg", "kitti_gt/")
+            with self.assertRaisesRegex(RegistryError, "declares dataset_folder"):
+                dataset_registry.verify_staged(spec, Path(root))
+
+    def test_missing_config_fails(self):
+        spec = dataset_registry.dataset("kitti")
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaisesRegex(RegistryError, "staged config not found"):
+                dataset_registry.verify_staged(spec, Path(root))
+
+    def test_invalid_json_fails(self):
+        spec = dataset_registry.dataset("kitti")
+        with tempfile.TemporaryDirectory() as root:
+            (Path(root) / "kitti-vio_slam_gt.cfg").write_text("{not json", encoding="utf-8")
+            with self.assertRaisesRegex(RegistryError, "not valid JSON"):
+                dataset_registry.verify_staged(spec, Path(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/python_tools/cuvslam_tools/tests/test_dataset_registry.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_dataset_registry.py
@@ -13,8 +13,6 @@
 # of the software or derivative works thereof, you agree to be bound by this License.
 
 import json
-import os
-import re
 import subprocess
 import sys
 import tempfile
@@ -23,8 +21,6 @@ from pathlib import Path
 
 from cuvslam_tools import dataset_registry
 from cuvslam_tools.dataset_registry import DatasetSpec, EvalSpec, RegistryError
-
-REPO_ROOT = Path(__file__).resolve().parents[4]
 
 KITTI_PREPARE = "cuvslam_tools.dataset_preparation.kitti.prepare"
 
@@ -43,9 +39,9 @@ class TestShippedRegistry(unittest.TestCase):
     def test_shipped_registry_validates(self):
         dataset_registry.validate()
 
-    def test_kitti_and_euroc_records_match_the_previous_shell_records(self):
-        # Guards the refactor: these are the label, config path, and flags that
-        # scripts/run_eval.sh carried as pipe-delimited records, in the same order.
+    def test_active_eval_records_are_exact(self):
+        # run_eval.sh passes these straight to cuvslam_app, and the KPI history is
+        # keyed on the derived prefixes, so any change here reindexes the history.
         expected = [
             (
                 "kitti",
@@ -92,23 +88,13 @@ class TestShippedRegistry(unittest.TestCase):
             "import sys; from cuvslam_tools import dataset_registry as r; r.validate();"
             "[print(m) for m in ('numpy', 'cv2', 'scipy', 'PIL', 'h5py', 'yaml') if m in sys.modules]"
         )
-        completed = subprocess.run(
-            [sys.executable, "-c", probe],
-            cwd=REPO_ROOT,
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "tools" / "python_tools")},
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        completed = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
         self.assertEqual(completed.stdout.strip(), "", f"validating the registry imported {completed.stdout.split()}")
 
-    def test_registry_cli_runs_without_the_package_installed(self):
-        # CI shell wrappers call the module with PYTHONPATH alone, inside an image
-        # where nothing is pip installed.
+    def test_registry_is_runnable_as_a_module(self):
+        # CI shell wrappers invoke `python3 -m cuvslam_tools.dataset_registry`.
         completed = subprocess.run(
             [sys.executable, "-m", "cuvslam_tools.dataset_registry", "eval-records"],
-            cwd=REPO_ROOT,
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT / "tools" / "python_tools")},
             capture_output=True,
             text=True,
             check=True,
@@ -117,14 +103,10 @@ class TestShippedRegistry(unittest.TestCase):
         self.assertEqual([row[0] for row in rows], ["kitti", "euroc"])
         self.assertTrue(all(len(row) == 4 for row in rows), rows)
 
-    def test_every_provisioning_workflow_choice_is_a_registry_dataset(self):
-        workflow = (REPO_ROOT / ".github" / "workflows" / "provision-datasets.yml").read_text(encoding="utf-8")
-        block = re.search(r"options:\n((?:\s+-\s+\S+\n)+)", workflow)
-        self.assertIsNotNone(block, "could not find the dataset choice options block")
-        choices = re.findall(r"-\s+(\S+)", block.group(1))
-        self.assertTrue(choices)
-        for choice in choices:
-            self.assertIn(choice, dataset_registry.DATASETS, f"workflow offers unknown dataset '{choice}'")
+    def test_unknown_dataset_is_rejected_with_the_known_ids(self):
+        # provision_dataset.sh relies on this to reject a stale workflow choice.
+        with self.assertRaisesRegex(RegistryError, r"unknown dataset 'nope' \(known: euroc, kitti, tartan, tum\)"):
+            dataset_registry.validate(["nope"])
 
     def test_preparation_modules_expose_a_callable_prepare(self):
         # Imports the converters, so it is the one test that pays that cost.
@@ -158,8 +140,7 @@ class TestValidationFailures(unittest.TestCase):
         with self.assertRaisesRegex(RegistryError, "bare filename"):
             self._validate({"kitti": spec})
 
-    def test_hyphenated_prefix_is_rejected_before_it_can_collide(self):
-        # tartan-flaky-... would derive TARTAN and overwrite the stable report.
+    def test_config_must_end_with_cfg(self):
         spec = DatasetSpec("kitti", KITTI_PREPARE, (stereo_eval(config="kitti.txt"),))
         with self.assertRaisesRegex(RegistryError, "must end with .cfg"):
             self._validate({"kitti": spec})


### PR DESCRIPTION
A dataset name was written down in seven places with nothing checking that they agreed: two shell arrays, a subdirectory case statement, the workflow choice list, a five-field pipe-delimited eval record, the dataset_folder baked into each shipped reporter config, and the KPI baseline keys. The couplings were invisible, and two were already wrong: tartan and tum returned a root one level below what provisioning tarred, undetected because neither is evaluated.

Add dataset_registry.py as the single source of truth. The dataset ID is the only name; the preparation module, the tarball, the staged directory, and the mount all derive from it. prepare() returns the directory to archive, which deletes dataset_upload_subdir and fixes the tartan and tum layouts without touching tartan. An evaluation is identified by its reporter config filename, and the KPI prefix is derived from that name rather than declared a second time.

Validation runs at the top of staging and provisioning, so a fault fails in seconds instead of after a download. It rejects duplicate IDs, missing modules, malformed flags, unknown suites or gating, an unrecognized --odometry_mode, and two records deriving one KPI identity. After extraction, verify-staged checks the shipped config's dataset_folder against the ID.

The module is standard library only and imports converters lazily, so it runs with PYTHONPATH alone inside cuvslam-ci:local. KITTI and EuRoC resolve to byte-identical labels, config paths, flags, and order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized dataset management for preparation, staging, and evaluation.
  * Added registry-based dataset validation, evaluation record generation, and staged configuration checks.
  * Added support for filtering evaluation datasets by suite.
  * Standardized dataset IDs across archives, staged directories, mounts, and evaluation workflows.

* **Bug Fixes**
  * Improved failure handling for invalid registries, missing datasets, empty evaluation lists, and incorrectly staged configurations.

* **Documentation**
  * Updated CI and evaluation guidance to reflect registry-driven dataset workflows and supported evaluation datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->