### PR TITLE
[fix] Put every SBA near plane on MINIMUM_HITHER

### DIFF
--- a/libs/cuda_modules/cuda_kernels/sba_imu_v1.cu
+++ b/libs/cuda_modules/cuda_kernels/sba_imu_v1.cu
@@ -26,6 +26,7 @@
 #include "cuda_modules/cuda_kernels/cuda_matrix.h"
 #include "cuda_modules/cuda_kernels/cuda_sba_common.h"
 #include "cuda_modules/cuda_kernels/cuda_sba_v1.h"
+#include "epipolar/near_plane.h"
 
 namespace cuvslam::cuda::sba_imu {
 
@@ -706,7 +707,7 @@ __global__ void evaluate_cost_stage_2_kernel(
     cuvslam::cuda::Vecf3 p_c;
     mul_add(problem_rig_camera_from_rig_linear, v2, problem_rig_camera_from_rig_translation, p_c);
 
-    if (p_c.d_[2] > 0.f) {
+    if (cuvslam::epipolar::IsDepthInFront(p_c.d_[2])) {
       cuvslam::cuda::Vecf2 r;
       r.d_[0] = p_c.d_[0] / p_c.d_[2] - problem_observation_xys.d_[0];
       r.d_[1] = p_c.d_[1] / p_c.d_[2] - problem_observation_xys.d_[1];
@@ -939,7 +940,7 @@ __global__ void update_model_stage_1_kernel(
   cuvslam::cuda::Matf23 model_repr_jacobians_jt{0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
   cuvslam::cuda::Matf23 model_repr_jacobians_jr{0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
   cuvslam::cuda::Matf23 model_repr_jacobians_jp{0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
-  if (p_c.d_[2] > 0.f) {
+  if (cuvslam::epipolar::IsDepthInFront(p_c.d_[2])) {
     cuvslam::cuda::Matf33 Rimu_from_w = imu_from_w_linear;
     cuvslam::cuda::Matf33 Rcam_from_imu = cam_from_imu_linear;
 

--- a/libs/cuda_modules/cuda_kernels/sba_v1.cu
+++ b/libs/cuda_modules/cuda_kernels/sba_v1.cu
@@ -21,6 +21,7 @@
 
 #include "cuda_modules/cuda_kernels/cuda_matrix.h"
 #include "cuda_modules/cuda_kernels/cuda_sba_v1.h"
+#include "epipolar/near_plane.h"
 
 #define USE_XAVIER_OPTIMIZATION true
 /*
@@ -392,7 +393,7 @@ __global__ void calc_jacobians_kernel(GPUModelFunctionMeta function_meta, GPUBun
   float3 p_c;
   Transform(camera_from_world, p_w.coords, p_c);
 
-  if (p_c.z > 1.f) {
+  if (cuvslam::epipolar::IsDepthInFront(p_c.z)) {
     float2 prediction = {p_c.x / p_c.z, p_c.y / p_c.z};
     float2 r = {obs.xy.x - prediction.x, obs.xy.y - prediction.y};
 
@@ -665,7 +666,7 @@ __global__ void evaluate_cost_kernel(float *cost, int *num_skipped, GPUBundleAdj
     float3 p_c;
     Transform(cam_poses[camera_id], p_r, p_c);
 
-    if (p_c.z > 1.f) {
+    if (cuvslam::epipolar::IsDepthInFront(p_c.z)) {
       float2 r = {
           obs.xy.x - p_c.x / p_c.z,
           obs.xy.y - p_c.y / p_c.z,

--- a/libs/cuda_modules/test/sba_test.cpp
+++ b/libs/cuda_modules/test/sba_test.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <random>
 
 #include "benchmark_utils.h"
@@ -1394,9 +1395,10 @@ TEST(Cuda, SBANearFieldObservationsCarryWeightGpu) {
   EXPECT_TRUE(std::isfinite(problem.initial_cost)) << "every near-field observation was skipped on the GPU";
 }
 
-// The other side of the boundary: tightening the IMU bundlers off a bare zero only means anything
-// if points inside the near plane are still refused. A problem made entirely of them is infeasible,
-// which is what the num_skipped path reports.
+// The other side of the boundary: moving the guard onto MINIMUM_HITHER only means something if
+// points inside the near plane are still refused. A problem made entirely of them is infeasible,
+// which is what the num_skipped path reports. Checked on both implementations, because each kernel
+// carries its own copy of the comparison.
 TEST(Cuda, SBAObservationsInsideTheNearPlaneAreSkipped) {
   camera::Rig rig = MakeDefaultRig();
 
@@ -1415,6 +1417,48 @@ TEST(Cuda, SBAObservationsInsideTheNearPlaneAreSkipped) {
   update.point.resize(problem.points.size(), Vector3T::Zero());
   update.pose.resize(problem.rig_from_world.size(), Isometry3T::Identity());
   EXPECT_FALSE(std::isfinite(EvaluateCost(problem, update)));
+
+  const int num_points = static_cast<int>(problem.points.size());
+  const int num_poses = static_cast<int>(problem.rig_from_world.size());
+  const int num_observations = static_cast<int>(problem.observation_xys.size());
+
+  cuda::sba::GPUBundleAdjustmentProblem gpu_problem(num_points, num_poses, num_observations);
+  cuda::sba::GPUModelFunction gpu_function(num_observations);
+  cuda::sba::GPUParameterUpdate gpu_update(num_points, num_poses);
+  gpu_problem.set_rig(rig);
+
+  cuda::GPUArrayPinned<float> gpu_cost{1};
+  cuda::GPUArrayPinned<int> gpu_num_skipped{1};
+  cuda::Stream s;
+
+  sba::BundleAdjustmentProblem gpu_side = problem;
+  ASSERT_TRUE(gpu_problem.set(gpu_side, s.get_stream()));
+  CUDA_CHECK(update_model(gpu_function.meta(), gpu_problem.meta(), gpu_side.robustifier_scale, s.get_stream()));
+
+  cuda::sba::temporary::ParameterUpdate update_temp = to_temporary(update);
+  ASSERT_TRUE(gpu_update.set(update_temp, s.get_stream()));
+  CUDA_CHECK(evaluate_cost(gpu_cost.ptr(), gpu_num_skipped.ptr(), gpu_problem.meta(), gpu_update.meta(),
+                           gpu_side.robustifier_scale, s.get_stream()));
+
+  gpu_cost.copy(cuda::GPUCopyDirection::ToCPU, s.get_stream());
+  gpu_num_skipped.copy(cuda::GPUCopyDirection::ToCPU, s.get_stream());
+  CUDA_CHECK(cudaStreamSynchronize(s.get_stream()));
+
+  ASSERT_TRUE(gpu_problem.get(gpu_side, s.get_stream()));
+  ModelFunction gpu_model;
+  ASSERT_TRUE(gpu_function.get(gpu_side.observation_xys.size(), gpu_model, s.get_stream()));
+  for (int i = 0; i < num_observations; ++i) {
+    EXPECT_EQ(gpu_model.point_jacobians[i].norm(), 0.f) << "GPU observation " << i << " inside the near plane was kept";
+    EXPECT_EQ(gpu_model.robustifier_weights[i], 0.f);
+  }
+
+  // evaluate_cost_kernel leaves a fully skipped problem at a cost of zero; the infinity is applied
+  // by SchurComplementBundlerGpu::Impl::evaluated_cost from num_skipped, so assert on that and map
+  // it the way the bundler does to line the check up with the CPU one above.
+  EXPECT_EQ(gpu_num_skipped[0], num_observations);
+  const float gpu_evaluated_cost =
+      gpu_num_skipped[0] == num_observations ? std::numeric_limits<float>::infinity() : gpu_cost[0];
+  EXPECT_FALSE(std::isfinite(gpu_evaluated_cost));
 }
 
 TEST(Cuda, DISABLED_SBABuildReducedSystem) {

--- a/libs/cuda_modules/test/sba_test.cpp
+++ b/libs/cuda_modules/test/sba_test.cpp
@@ -27,6 +27,7 @@
 #include "common/include_gtest.h"
 #include "cuda_modules/cuda_kernels/cuda_sba_v1.h"
 #include "cuda_modules/sba.h"
+#include "epipolar/near_plane.h"
 #include "math/twist.h"
 #include "profiler/profiler.h"
 #include "sba/bundle_adjustment_problem.h"
@@ -37,6 +38,9 @@ using namespace cuvslam;
 
 using ProfilerDomain = cuvslam::profiler::DefaultProfiler::DomainHelper;
 ProfilerDomain helper("SBA_TEST");
+
+// Keeps the randomly generated parity problems away from the near plane, where 1/z blows up.
+constexpr float kWellConditionedDepth = 1.f;
 
 void GenerateProblem(sba::BundleAdjustmentProblem& problem, const camera::Rig& rig,
                      const Matrix2T& obs_info = Matrix2T::Identity(), const int num_points = 400,
@@ -82,7 +86,11 @@ void GenerateProblem(sba::BundleAdjustmentProblem& problem, const camera::Rig& r
         // cam space
         Vec3 p = rig.camera_from_rig[cam_idx] * rig_from_world[pose_idx] * points[point_idx];
 
-        if (p.z() <= 1.f) {
+        // Not the near plane: this is scene construction. The parity tests compare CPU and GPU
+        // solutions with isApprox, and an observation just past MINIMUM_HITHER has 1/z Jacobian
+        // entries that wreck the conditioning of the random problem. Where the guard actually sits
+        // is pinned by the near-field tests below.
+        if (p.z() <= kWellConditionedDepth) {
           continue;
         }
 
@@ -116,6 +124,55 @@ static camera::Rig MakeDefaultRig() {
   rig.camera_from_rig[1].translate(Eigen::Vector3f(0.125f, 0., 0.f));
 
   return rig;
+}
+
+// GenerateProblem draws depths in [2, 16] m, so nothing in the suite ever lands in the band between
+// the near plane and the 1 m the bundlers used to carry. This one places every point at a chosen
+// camera-frame depth instead, and projects without a near filter, so a test can put observations
+// deliberately on either side of MINIMUM_HITHER.
+void GenerateFixedDepthProblem(sba::BundleAdjustmentProblem& problem, const camera::Rig& rig, float min_depth,
+                               float max_depth, int num_points = 60, int num_poses = 3) {
+  using namespace cuvslam;
+  problem = {};
+
+  std::mt19937 rng(7);
+  std::uniform_real_distribution<float> depth(min_depth, max_depth);
+  std::uniform_real_distribution<float> xy(-0.05f, 0.05f);
+  // Keep the pose perturbation far smaller than the depth band so every observation stays on the
+  // side of the near plane the caller asked for.
+  std::uniform_real_distribution<float> dt(-0.01f, 0.01f);
+  std::uniform_real_distribution<float> domega(-0.01f, 0.01f);
+
+  for (int i = 0; i < num_poses; ++i) {
+    Vector6T log_pose;
+    log_pose << domega(rng), domega(rng), domega(rng), dt(rng), dt(rng), dt(rng);
+    Isometry3T pose;
+    math::Exp(pose, log_pose);
+    problem.rig_from_world.push_back(pose);
+  }
+
+  for (int i = 0; i < num_points; ++i) {
+    problem.points.emplace_back(xy(rng), xy(rng), depth(rng));
+  }
+
+  for (int pose_idx = 0; pose_idx < num_poses; ++pose_idx) {
+    for (int point_idx = 0; point_idx < num_points; ++point_idx) {
+      for (int8_t cam_idx = 0; cam_idx < rig.num_cameras; ++cam_idx) {
+        const Vector3T p = rig.camera_from_rig[cam_idx] * problem.rig_from_world[pose_idx] * problem.points[point_idx];
+        problem.observation_xys.push_back(p.topRows(2) / p.z());
+        problem.observation_infos.push_back(Matrix2T::Identity());
+        problem.camera_ids.push_back(cam_idx);
+        problem.point_ids.push_back(point_idx);
+        problem.pose_ids.push_back(pose_idx);
+      }
+    }
+  }
+
+  problem.num_fixed_points = 0;
+  problem.num_fixed_key_frames = 1;
+  problem.rig.num_cameras = rig.num_cameras;
+  problem.rig.camera_from_rig[0] = rig.camera_from_rig[0];
+  problem.rig.camera_from_rig[1] = rig.camera_from_rig[1];
 }
 
 cuda::sba::temporary::ReducedSystem to_temporary(
@@ -1294,6 +1351,70 @@ TEST(Cuda, SBASolverConvergesOnExactObservations) {
   EXPECT_TRUE(std::isfinite(problem.last_cost));
   EXPECT_LT(problem.last_cost, problem.initial_cost);
   EXPECT_LT(problem.iterations, problem.max_iterations);
+}
+
+// The visual bundlers used to skip anything closer than a hard-coded 1 m while the rest of the
+// system guarded at MINIMUM_HITHER (0.1). Landmarks in that band reached the bundler, then carried
+// zero weight in the cost and in both Jacobians. These pin the guard where the shared predicate
+// puts it, in the two places the CPU bundler applies it.
+TEST(Cuda, SBANearFieldObservationsCarryWeightCpu) {
+  camera::Rig rig = MakeDefaultRig();
+
+  sba::BundleAdjustmentProblem problem;
+  GenerateFixedDepthProblem(problem, rig, 0.3f, 0.8f);
+  ASSERT_FALSE(problem.observation_xys.empty());
+
+  ModelFunction model;
+  UpdateModel(model, problem);
+
+  for (size_t i = 0; i < problem.observation_xys.size(); ++i) {
+    EXPECT_GT(model.point_jacobians[i].norm(), 0.f) << "near-field observation " << i << " was skipped";
+    EXPECT_GT(model.robustifier_weights[i], 0.f) << "near-field observation " << i << " got zero weight";
+  }
+
+  ParameterUpdate update;
+  update.point.resize(problem.points.size(), Vector3T::Zero());
+  update.pose.resize(problem.rig_from_world.size(), Isometry3T::Identity());
+  // Observations are exact projections, so a fed-back state costs nothing - the point is that the
+  // cost is a real number rather than the infinity a fully skipped problem reports.
+  EXPECT_TRUE(std::isfinite(EvaluateCost(problem, update)));
+}
+
+// Same problem through the GPU bundler: the two implementations have always agreed on where this
+// plane sits, and they still have to.
+TEST(Cuda, SBANearFieldObservationsCarryWeightGpu) {
+  camera::Rig rig = MakeDefaultRig();
+
+  sba::BundleAdjustmentProblem problem;
+  GenerateFixedDepthProblem(problem, rig, 0.3f, 0.8f);
+  problem.max_iterations = 10;
+
+  sba::SchurComplementBundlerGpu bundler;
+  EXPECT_TRUE(bundler.solve(problem));
+  EXPECT_TRUE(std::isfinite(problem.initial_cost)) << "every near-field observation was skipped on the GPU";
+}
+
+// The other side of the boundary: tightening the IMU bundlers off a bare zero only means anything
+// if points inside the near plane are still refused. A problem made entirely of them is infeasible,
+// which is what the num_skipped path reports.
+TEST(Cuda, SBAObservationsInsideTheNearPlaneAreSkipped) {
+  camera::Rig rig = MakeDefaultRig();
+
+  sba::BundleAdjustmentProblem problem;
+  GenerateFixedDepthProblem(problem, rig, 0.02f, 0.08f);
+  ASSERT_FALSE(problem.observation_xys.empty());
+
+  ModelFunction model;
+  UpdateModel(model, problem);
+  for (size_t i = 0; i < problem.observation_xys.size(); ++i) {
+    EXPECT_EQ(model.point_jacobians[i].norm(), 0.f) << "observation " << i << " inside the near plane was kept";
+    EXPECT_EQ(model.robustifier_weights[i], 0.f);
+  }
+
+  ParameterUpdate update;
+  update.point.resize(problem.points.size(), Vector3T::Zero());
+  update.pose.resize(problem.rig_from_world.size(), Isometry3T::Identity());
+  EXPECT_FALSE(std::isfinite(EvaluateCost(problem, update)));
 }
 
 TEST(Cuda, DISABLED_SBABuildReducedSystem) {

--- a/libs/epipolar/CMakeLists.txt
+++ b/libs/epipolar/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HEADERS
     fundamental_ransac.h
     homography.h
     homography_ransac.h
+    near_plane.h
     optscalar_triangle_ransac.h
     point_reconstruction.h
     points_normalization.h

--- a/libs/epipolar/camera_selection.h
+++ b/libs/epipolar/camera_selection.h
@@ -25,17 +25,9 @@
 #include "common/types.h"
 #include "common/vector_2t.h"
 #include "common/vector_3t.h"
+#include "epipolar/near_plane.h"
 
 namespace cuvslam::epipolar {
-
-namespace FrustumProperties {
-/// Minimum positive depth (camera +Z forward, OpenCV) for a point to be considered in front of the camera.
-const float MINIMUM_HITHER = 0.1f;
-}  // namespace FrustumProperties
-
-/// True when a camera-local depth clears the near plane. Prefer this over a hand-written
-/// comparison so every guard treats the boundary the same way.
-inline bool IsDepthInFront(float z) { return z > FrustumProperties::MINIMUM_HITHER; }
 
 enum class TriangulationState { None, Triangulated, AlmostParallel };
 

--- a/libs/epipolar/near_plane.h
+++ b/libs/epipolar/near_plane.h
@@ -1,0 +1,40 @@
+
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+ * the further development of AI and robotics technologies. Such software has been designed, tested,
+ * and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+ * solely with such hardware.
+ * Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+ * modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+ * outputs generated using the software or derivative works thereof. Any code contributions that you
+ * share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+ * in future releases without notice or attribution.
+ * By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+ * of the software or derivative works thereof, you agree to be bound by this License.
+ */
+
+#pragma once
+
+// The near plane guard lives in its own header because the SBA CUDA kernels need it too, and
+// camera_selection.h pulls in Eigen and libs/common, neither of which belongs in device code.
+// Keep this file free of includes so a .cu can take it as-is.
+#if defined(__CUDACC__)
+#define CUVSLAM_NEAR_PLANE_FN __host__ __device__ inline
+#else
+#define CUVSLAM_NEAR_PLANE_FN inline
+#endif
+
+namespace cuvslam::epipolar {
+
+namespace FrustumProperties {
+/// Minimum positive depth (camera +Z forward, OpenCV) for a point to be considered in front of the camera.
+constexpr float MINIMUM_HITHER = 0.1f;
+}  // namespace FrustumProperties
+
+/// True when a camera-local depth clears the near plane. Prefer this over a hand-written
+/// comparison so every guard treats the boundary the same way.
+CUVSLAM_NEAR_PLANE_FN bool IsDepthInFront(float z) { return z > FrustumProperties::MINIMUM_HITHER; }
+
+}  // namespace cuvslam::epipolar

--- a/libs/imu/CMakeLists.txt
+++ b/libs/imu/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIBS
     camera
     common
     cuvslam_math
+    epipolar
     profiler
 )
 

--- a/libs/imu/imu_sba_fixed_vel.cpp
+++ b/libs/imu/imu_sba_fixed_vel.cpp
@@ -17,6 +17,7 @@
 
 #include "common/log_types.h"
 #include "common/statistic.h"
+#include "epipolar/near_plane.h"
 #include "math/robust_cost_function.h"
 #include "math/twist.h"
 
@@ -250,7 +251,7 @@ float IMUBundlerCpuFixedVel::EvaluateCost(const ImuBAProblem& problem, const int
 
     p_c = cam_from_imu[camera_idx] * imu_from_w[pose_idx] * p_w;
 
-    if (p_c.z() > 0) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       r = p_c.topRows(2) / p_c.z() - problem.observation_xys[obs];
       cost += ROBUST_COST(r.dot(problem.observation_infos[obs] * r), problem.robustifier_scale);
     } else {
@@ -500,7 +501,7 @@ void IMUBundlerCpuFixedVel::UpdateModel(internal::ModelFunction& model, ImuBAPro
     Matrix3T Rimu_from_w = imu_from_w.linear();
     Matrix3T Rcam_from_imu = cam_from_imu[camera_idx].linear();
 
-    if (p_c.z() > 0) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       Vector2T prediction = p_c.topRows(2) / p_c.z();
       Vector2T r = prediction - problem.observation_xys[obs];
 

--- a/libs/imu/soft_inertial_pnp.cpp
+++ b/libs/imu/soft_inertial_pnp.cpp
@@ -19,6 +19,7 @@
 
 #include "common/imu_calibration.h"
 #include "common/log.h"
+#include "epipolar/near_plane.h"
 #include "math/robust_cost_function.h"
 #include "math/twist.h"
 
@@ -93,7 +94,7 @@ void CalcOutliers(const imu::ImuCalibration& imu_calibration, const StereoPnPInp
 
     p_c = cam_from_w[camera_idx] * p_w;
 
-    if (p_c.z() > 1.f) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       r = p_c.topRows(2) / p_c.z() - input.observation_xys[obs];
       float err = r.dot(input.observation_infos[obs] * r);
       is_obs_outlier[obs] = err > thresh;
@@ -150,7 +151,7 @@ float EvaluateCost(const imu::ImuCalibration& imu_calibration, const StereoPnPIn
 
     p_c = input.rig.camera_from_rig[camera_idx] * rig_from_imu * pu2.w_from_imu.inverse() * p_w;
 
-    if (p_c.z() > 1.f) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       r = p_c.topRows(2) / p_c.z() - input.observation_xys[obs];
       cost += ROBUST_COST(r.dot(input.observation_infos[obs] * r), input.robustifier_scale);
     }
@@ -262,7 +263,7 @@ void build_hessian(const imu::ImuCalibration& imu_calibration, const StereoPnPIn
     const Isometry3T& w_from_imu = pose_right.w_from_imu;
     Vector3T p_c = problem.rig.camera_from_rig[camera_idx] * rig_from_imu * w_from_imu.inverse() * p_w;
 
-    if (p_c.z() > 1.f) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       Vector2T prediction = p_c.topRows(2) / p_c.z();
       Vector2T r = prediction - problem.observation_xys[obs];
 

--- a/libs/sba/schur_complement_bundler_cpu.cpp
+++ b/libs/sba/schur_complement_bundler_cpu.cpp
@@ -21,6 +21,7 @@
 #include "common/log_types.h"
 #include "common/rotation_utils.h"
 #include "common/statistic.h"
+#include "epipolar/near_plane.h"
 #include "math/robust_cost_function.h"
 #include "math/twist.h"
 
@@ -93,7 +94,7 @@ void schur_complement_bundler_cpu_internal::UpdateModel(ModelFunction& model, Bu
     // from observations_start indirectly
     Vec3 p_c = camera_from_world * p_w;
 
-    if (p_c.z() > 1.f) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       Vec2 prediction = p_c.topRows(2) / p_c.z();
       Vec2 r = problem.observation_xys[observation] - prediction;
 
@@ -316,7 +317,7 @@ float schur_complement_bundler_cpu_internal::EvaluateCost(const BundleAdjustment
     // from observations_start indirectly
     Vec3 p_c = problem.rig.camera_from_rig[camera_idx] * p_r;
 
-    if (p_c.z() > 1.f) {
+    if (epipolar::IsDepthInFront(p_c.z())) {
       Vec2 r = problem.observation_xys[observation] - p_c.topRows(2) / p_c.z();
 
       const Matrix2T& info = problem.observation_infos[observation];

--- a/libs/sba/schur_complement_bundler_gpu.cpp
+++ b/libs/sba/schur_complement_bundler_gpu.cpp
@@ -102,7 +102,7 @@ bool SchurComplementBundlerGpu::solve(BundleAdjustmentProblem& problem) {
 SchurComplementBundlerGpu::Impl::Impl(int max_points, int max_poses) : max_points(max_points), max_poses(max_poses) {}
 
 float SchurComplementBundlerGpu::Impl::evaluated_cost(int num_observations) const {
-  // An observation that lands behind its camera is skipped and adds nothing, so a state that hides
+  // An observation closer than the near plane is skipped and adds nothing, so a state that hides
   // every one of them would otherwise score a perfect zero. That is infeasible, not optimal - the
   // IMU bundler reports it the same way.
   if (gpu_num_skipped_[0] == num_observations) {


### PR DESCRIPTION
The SBA family carried three different near planes. The visual bundlers skipped anything closer than a hard-coded 1 m (schur_complement_bundler_cpu.cpp and sba_v1.cu), the IMU bundlers used a bare 0 (imu_sba_fixed_vel.cpp and sba_imu_v1.cu), the soft inertial PnP used 1 m again, and the rest of the system guarded at FrustumProperties::MINIMUM_HITHER (0.1). All eleven sites date to the same import commit and had never been revisited. CPU and GPU agreed with each other within each path, so this never showed up as a parity failure.

Nothing filters depth upstream: service_sba.h hands the bundler every landmark that has a pose. A landmark between 0.1 m and 1 m was therefore triangulated, kept, and then carried zero weight in the cost and in both Jacobians - invisible to the solve. A skipped observation also contributes nothing rather than a penalty, so an LM trial step that pushes a 1.05 m landmark to 0.95 m lowers the cost purely by hiding it. That is the per-observation form of the all-or-nothing bug #105 fixed, and a 0.1 m plane leaves a tenth of the room for it. The bare 0 on the IMU side is the hazard #116 fixed in the depth point map: the code divides by p_c.z immediately after, so z = 1e-6 sends an enormous Jacobian entry into the normal equations.

The CUDA kernels cannot include camera_selection.h - it pulls in Eigen and libs/common, and cuda_kernels links neither - so the guard moves into a new self-contained epipolar/near_plane.h that is safe in device code, and camera_selection.h includes it. There is still exactly one definition of the constant and one of the predicate.

This changes tracking behaviour on every sequence, since near-field observations now carry weight where they used to be dropped. It needs an eval run before it is merged.

Tests: sba_test.cpp gains near-field coverage on both the CPU and the GPU bundler, and the other side of the boundary. Verified that both near-field cases fail with the guards put back to 1 m. GenerateProblem keeps a 1 m filter of its own, now named for what it is - routing it through the shared guard admits observations whose 1/z Jacobians break the CPU/GPU isApprox comparisons in SBASolver and SBAParameterUpdaterComputeUpdate.

Not covered: soft_inertial_pnp.cpp has no runnable tests, because imu_pnp_test.cpp is entirely inside an #if 0, and the IMU bundler's UpdateModel and EvaluateCost are private.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of observations near the camera with a consistent near-plane depth rule.
  * Valid near-field observations now retain Jacobians, weights, and finite costs.
  * Observations too close to the camera are safely skipped to prevent invalid calculations.
  * CPU and GPU processing now apply the same depth-validation behavior.

* **Tests**
  * Added coverage for valid, boundary, and below-near-plane observation depths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->