### PR TITLE
[test] disable flaky SBASolverSpeedUp benchmark test

### DIFF
--- a/libs/cuda_modules/test/sba_test.cpp
+++ b/libs/cuda_modules/test/sba_test.cpp
@@ -466,7 +466,7 @@ TEST(Cuda, SBABuildFullSystem) {
   }
 }
 
-TEST(Cuda, SBASolverSpeedUp) {
+TEST(Cuda, DISABLED_SBASolverSpeedUp) {
   camera::Rig rig = MakeDefaultRig();
 
   ReducedSystem reduced_system;


### PR DESCRIPTION
The test asserts GPU solve time beats CPU solve time, which is timing- dependent and flaky depending on machine load; skip it via GTest's DISABLED_ prefix rather than removing the benchmark code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled the CUDA solver performance benchmark test; its benchmarking logic remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->