### PR TITLE
[refactor] Make Tracker take an explicit execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Changed
+
+- `Tracker` now takes a required `Tracker::Mode` (`cuvslam.Tracker.Mode` in Python) as its second
+  constructor argument, choosing between odometry alone or odometry with SLAM, and between running
+  the bundle adjuster and SLAM on background threads (realtime) or in the calling thread (offline).
+  The mode has to agree with `Odometry::Config::async_sba` and `Slam::Config::sync_mode`: `Tracker`
+  checks them and throws `std::invalid_argument` on a mismatch rather than overwriting them. A
+  `slam_config` is now rejected in the odometry-only modes
+
 ### Added
 
 - `Slam::Config::delay_warning_queue_size`: warns in verbose mode when more than the configured number of commands

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -168,17 +168,25 @@ In this mode, SBA and SLAM run on the main thread and block until completion rat
 This makes computation more stable and tests more reproducible, but it does not support high frame rates.
 Feed images to cuVSLAM frame by frame.
 
+Pick one of the `Tracker` offline modes and set the two configuration fields to match; `Tracker`
+rejects a mode that disagrees with them.
+
 **C++ API**
 
 ```cpp
-cuvslam::Odometry::Config::async_sba = false;
-cuvslam::Slam::Config::sync_mode = true;
+cuvslam::Odometry::Config odometry_config;
+odometry_config.async_sba = false;
+cuvslam::Slam::Config slam_config;
+slam_config.sync_mode = true;
+cuvslam::Tracker tracker{rig, cuvslam::Tracker::Mode::OdometryWithSlamOffline, odometry_config, &slam_config};
 ```
 
 **Python API**
 
-1. [cuvslam.Odometry.Config.async_sba](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Odometry.Config.async_sba)
-2. [cuvslam.Slam.Config.sync_mode](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Slam.Config.sync_mode)
+1. [cuvslam.Tracker.Mode](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Tracker.Mode) —
+   `OdometryOnlyOffline` or `OdometryWithSlamOffline`
+2. [cuvslam.Odometry.Config.async_sba](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Odometry.Config.async_sba)
+3. [cuvslam.Slam.Config.sync_mode](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Slam.Config.sync_mode)
 
 **Isaac ROS**
 
@@ -616,11 +624,13 @@ to match your environment and accuracy requirements.
 
 ## Step 14: Run in async mode
 
-For real-time or high-throughput operation, enable async mode. Adjust these parameters to balance latency and throughput:
+For real-time or high-throughput operation, switch to a realtime `Tracker::Mode` and set the two
+configuration fields to match. Adjust these parameters to balance latency and throughput:
 
-1. `Odometry::Config::async_sba`
-2. `Slam::Config::throttling_time_ms`
-3. `Slam::Config::sync_mode`
+1. `Tracker::Mode::OdometryOnlyRealtime` or `Tracker::Mode::OdometryWithSlamRealtime`
+2. `Odometry::Config::async_sba` (must be `true` in a realtime mode)
+3. `Slam::Config::sync_mode` (must be `false` in a realtime mode)
+4. `Slam::Config::throttling_time_ms`
 
 ### Verify SLAM keeps up with odometry
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -188,6 +188,9 @@ cuvslam::Tracker tracker{rig, cuvslam::Tracker::Mode::OdometryWithSlamOffline, o
 2. [cuvslam.Odometry.Config.async_sba](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Odometry.Config.async_sba)
 3. [cuvslam.Slam.Config.sync_mode](https://nvidia-isaac.github.io/cuVSLAM/python/api.html#cuvslam.Slam.Config.sync_mode)
 
+`sync_mode` is a `Slam.Config` field, so it only applies to `OdometryWithSlamOffline`. The
+odometry-only modes take no `slam_config` at all — pass one and the tracker rejects it.
+
 **Isaac ROS**
 
 ROS cannot run cuVSLAM in blocking mode because `ros2 bag play` does not support blocking playback. Troubleshooting
@@ -631,6 +634,9 @@ configuration fields to match. Adjust these parameters to balance latency and th
 2. `Odometry::Config::async_sba` (must be `true` in a realtime mode)
 3. `Slam::Config::sync_mode` (must be `false` in a realtime mode)
 4. `Slam::Config::throttling_time_ms`
+
+Items 3 and 4 are `Slam::Config` fields, so they only apply to `OdometryWithSlamRealtime`. In
+`OdometryOnlyRealtime`, omit `slam_config` entirely.
 
 ### Verify SLAM keeps up with odometry
 

--- a/cuvslam-skills/cuvslam-onboard/SKILL.md
+++ b/cuvslam-skills/cuvslam-onboard/SKILL.md
@@ -256,9 +256,11 @@ With Rerun: `cmake -S . -B build -DUSE_RERUN=ON && cmake --build build --target 
 3. **Localize:** Load saved map, provide initial pose hint, call `tracker.slam.localize_in_map()`
 
 ```python
-odom_cfg = cuvslam.Odometry.Config(...)
-slam_cfg = cuvslam.Slam.Config(sync_mode=True)  # sync for reproducibility
-tracker = cuvslam.Tracker(cuvslam.Rig(...), odom_cfg, slam_cfg)
+odom_cfg = cuvslam.Odometry.Config(async_sba=False, ...)  # blocking SBA for reproducibility
+slam_cfg = cuvslam.Slam.Config(sync_mode=True)            # sync SLAM, same reason
+# The mode must agree with both fields; the tracker rejects a mismatch instead of overriding it.
+tracker = cuvslam.Tracker(cuvslam.Rig(...), cuvslam.Tracker.Mode.OdometryWithSlamOffline,
+                          odom_cfg, slam_cfg)
 
 odom_pose, slam_pose = tracker.track(...)
 slam = tracker.slam

--- a/cuvslam-skills/cuvslam-onboard/SKILL.md
+++ b/cuvslam-skills/cuvslam-onboard/SKILL.md
@@ -256,8 +256,8 @@ With Rerun: `cmake -S . -B build -DUSE_RERUN=ON && cmake --build build --target 
 3. **Localize:** Load saved map, provide initial pose hint, call `tracker.slam.localize_in_map()`
 
 ```python
-odom_cfg = cuvslam.Odometry.Config(async_sba=False, ...)  # blocking SBA for reproducibility
-slam_cfg = cuvslam.Slam.Config(sync_mode=True)            # sync SLAM, same reason
+odom_cfg = cuvslam.Odometry.Config(async_sba=False)  # blocking SBA for reproducibility
+slam_cfg = cuvslam.Slam.Config(sync_mode=True)       # sync SLAM, same reason
 # The mode must agree with both fields; the tracker rejects a mismatch instead of overriding it.
 tracker = cuvslam.Tracker(cuvslam.Rig(...), cuvslam.Tracker.Mode.OdometryWithSlamOffline,
                           odom_cfg, slam_cfg)

--- a/cuvslam-skills/cuvslam-troubleshoot/SKILL.md
+++ b/cuvslam-skills/cuvslam-troubleshoot/SKILL.md
@@ -91,7 +91,7 @@ Key parameters to note once you have the config:
   Knowing this up front directs the diagnosis toward vision, depth, or IMU root causes.
 - `rectified_images` (Isaac ROS) / `rectified_stereo_camera` (C++ API) — wrong value flips the entire stereo pipeline
 - `image_jitter_threshold_ms` — tolerated timestamp jitter between left/right images; too tight a value causes frames to be dropped silently
-- `async_sba` / `sync_mode` — affects reproducibility
+- `Tracker.Mode` plus the `async_sba` / `sync_mode` that must match it — affects reproducibility
 - `enable_slam` / loop closure settings — SLAM should only be tuned after odometry is solid
 - `denoise_input_images`, `imu_from_left` — sensor-specific flags
 - Any border/masking parameters — may inadvertently block features

--- a/cuvslam-skills/cuvslam-troubleshoot/commands/tracker.md
+++ b/cuvslam-skills/cuvslam-troubleshoot/commands/tracker.md
@@ -67,7 +67,7 @@ The tracker looks for the EDEX at `CUVSLAM_DATASETS/<edex>/<edex_filename>` and 
 
 | Flag | Default | Description |
 |---|---|---|
-| `-async_sba` | `false` | `false` = blocking SBA (deterministic). Keep `false` for debugging. |
+| `-async_sba` | `false` | `false` = blocking SBA (deterministic), and selects an offline `Tracker.Mode`. Keep `false` for debugging, with `-sync_slam=true`. |
 | `-slam_reproduce_mode` | `false` | Sync + non-random SLAM for exact reproducibility |
 
 ### SLAM

--- a/examples/euroc/cpp/track_euroc.cpp
+++ b/examples/euroc/cpp/track_euroc.cpp
@@ -513,7 +513,7 @@ int main(int argc, char **argv) {
     slam_config.enable_reading_internals = true;
 
     std::cout << "Initializing tracker (odometry + SLAM)..." << std::endl;
-    cuvslam::Tracker tracker(rig, odometry_config, &slam_config);
+    cuvslam::Tracker tracker(rig, cuvslam::Tracker::Mode::OdometryWithSlamOffline, odometry_config, &slam_config);
 
     // Reading SLAM data layers is not mirrored on Tracker, so reach the SLAM instance directly.
     // It is non-null here because the config above enables SLAM.

--- a/examples/euroc/track_euroc.py
+++ b/examples/euroc/track_euroc.py
@@ -102,7 +102,7 @@ odom_cfg = cuvslam.Odometry.Config(
 rig = get_rig(sequence_path)
 
 # Initialize tracker
-tracker = cuvslam.Tracker(rig, odom_cfg)
+tracker = cuvslam.Tracker(rig, cuvslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 print(f"cuVSLAM Tracker initilized with odometry mode: {cfg.odometry_mode}")
 
 # Track frames

--- a/examples/kitti/README.md
+++ b/examples/kitti/README.md
@@ -69,17 +69,17 @@ Below is an example demonstrating loop closure detection. When the vehicle revis
 To enable SLAM in PyCuVSLAM, you must provide a SLAM configuration when initializing the tracker:
 
 ```python
-odom_cfg = cuvslam.Odometry.Config(async_sba=..., ...)
-slam_cfg = cuvslam.Slam.Config(sync_mode=...)
+odom_cfg = cuvslam.Odometry.Config(async_sba=True)
+slam_cfg = cuvslam.Slam.Config(sync_mode=False)
 tracker = cuvslam.Tracker(cuvslam.Rig(...), cuvslam.Tracker.Mode.OdometryWithSlamRealtime, odom_cfg, slam_cfg)
 ```
 
 SLAM can operate in two modes, selected by the tracker mode. The mode has to agree with the two configuration fields, and the tracker reports an error if it does not: a realtime mode needs `async_sba=True` and `sync_mode=False`, an offline mode needs the opposite.
 
-- **Asynchronous (`Mode.OdometryWithSlamRealtime`, `sync_mode=False`, recommended for real-time applications):**
+- **Asynchronous (`Mode.OdometryWithSlamRealtime`, `async_sba=True`, `sync_mode=False`, recommended for real-time applications):**
   SLAM processing runs in a separate, non-blocking thread, allowing visual odometry to continue uninterrupted.
 
-- **Synchronous (`Mode.OdometryWithSlamOffline`, `sync_mode=True`):**
+- **Synchronous (`Mode.OdometryWithSlamOffline`, `async_sba=False`, `sync_mode=True`):**
   SLAM processing runs in the same thread as odometry, causing visual tracking to pause at each keyframe until all SLAM-related processing completes. This can cause noticeable delays (seconds-long pauses), making it unsuitable for real-time camera-based applications.
 
 Now, each call to `tracker.track` will return both an odometry and SLAM poses:

--- a/examples/kitti/README.md
+++ b/examples/kitti/README.md
@@ -69,17 +69,17 @@ Below is an example demonstrating loop closure detection. When the vehicle revis
 To enable SLAM in PyCuVSLAM, you must provide a SLAM configuration when initializing the tracker:
 
 ```python
-odom_cfg = cuvslam.Odometry.Config(...)
+odom_cfg = cuvslam.Odometry.Config(async_sba=..., ...)
 slam_cfg = cuvslam.Slam.Config(sync_mode=...)
-tracker = cuvslam.Tracker(cuvslam.Rig(...), odom_cfg, slam_cfg)
+tracker = cuvslam.Tracker(cuvslam.Rig(...), cuvslam.Tracker.Mode.OdometryWithSlamRealtime, odom_cfg, slam_cfg)
 ```
 
-SLAM can operate in two modes:
+SLAM can operate in two modes, selected by the tracker mode. The mode has to agree with the two configuration fields, and the tracker reports an error if it does not: a realtime mode needs `async_sba=True` and `sync_mode=False`, an offline mode needs the opposite.
 
-- **Asynchronous (`sync_mode=False`, recommended for real-time applications):**
+- **Asynchronous (`Mode.OdometryWithSlamRealtime`, `sync_mode=False`, recommended for real-time applications):**
   SLAM processing runs in a separate, non-blocking thread, allowing visual odometry to continue uninterrupted.
 
-- **Synchronous (`sync_mode=True`):**
+- **Synchronous (`Mode.OdometryWithSlamOffline`, `sync_mode=True`):**
   SLAM processing runs in the same thread as odometry, causing visual tracking to pause at each keyframe until all SLAM-related processing completes. This can cause noticeable delays (seconds-long pauses), making it unsuitable for real-time camera-based applications.
 
 Now, each call to `tracker.track` will return both an odometry and SLAM poses:
@@ -112,7 +112,7 @@ As a result, the initial pose displayed will reflect the localized position (no 
 
 - **Keep cameras stationary while localizing.** Ideally, an agent should be continuously exploring the area near the initial pose hint while localizing. However, in the current implementation, there is a delay before the localization result is applied to the SLAM pose, which causes unexpected jumps if the agent moves during this delay. For reliable localization, either move at a very slow speed or stop the agent for a couple of seconds while localization takes place.
 - **Continue calling `track()` after `localize_in_map()`.** You should continue supplying images to the library during localization. The asynchronous SLAM thread needs ongoing `track()` calls to process the localization request. Keep calling `track()` until the SLAM pose it returns reflects the localized position. If you test localization on recordings with moving cameras, call `track()` after `localize_in_map()` with the same image frame but with incrementing timestamps.
-- **If you experience trouble localizing or see pose jumps after localization, try synchronous SLAM mode** (`sync_mode=True`). In sync mode, localization completes within the `localize_in_map()` call. However, all SLAM operations also block the `track()` calls, resulting in a substantial slowdown.
+- **If you experience trouble localizing or see pose jumps after localization, try synchronous SLAM mode** (`Mode.OdometryWithSlamOffline` with `async_sba=False` and `sync_mode=True`). In sync mode, localization completes within the `localize_in_map()` call. However, all SLAM operations also block the `track()` calls, resulting in a substantial slowdown.
 - A redesign of the asynchronous SLAM pipeline is underway to remove these workarounds.
 
 ## Running PyCuVSLAM with input masks

--- a/examples/kitti/README.md
+++ b/examples/kitti/README.md
@@ -66,7 +66,7 @@ Below is an example demonstrating loop closure detection. When the vehicle revis
 
 ![Loop Closure Demonstration](../assets/tutorial_kitti_lc.gif)
 
-To enable SLAM in PyCuVSLAM, you must provide a SLAM configuration when initializing the tracker:
+To enable SLAM in PyCuVSLAM, pick a SLAM tracker mode — the mode is what turns SLAM on, not the configuration. `slam_config` is optional and only overrides the SLAM defaults, which already suit `Mode.OdometryWithSlamRealtime`; the example below passes one to show the fields discussed further down:
 
 ```python
 odom_cfg = cuvslam.Odometry.Config(async_sba=True)

--- a/examples/kitti/track_kitti.py
+++ b/examples/kitti/track_kitti.py
@@ -88,7 +88,7 @@ odom_cfg = cuvslam.Odometry.Config(
     enable_final_landmarks_export=True,
     rectified_stereo_camera=True
 )
-tracker = cuvslam.Tracker(cuvslam.Rig(cameras), odom_cfg)
+tracker = cuvslam.Tracker(cuvslam.Rig(cameras), cuvslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
 # Get timestamps from times.txt file
 timestamps = [

--- a/examples/kitti/track_kitti_masks.py
+++ b/examples/kitti/track_kitti_masks.py
@@ -94,7 +94,7 @@ odom_cfg = cuvslam.Odometry.Config(
     enable_final_landmarks_export=True,
     rectified_stereo_camera=True
 )
-tracker = cuvslam.Tracker(cuvslam.Rig(cameras), odom_cfg)
+tracker = cuvslam.Tracker(cuvslam.Rig(cameras), cuvslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
 timestamps = [
     int(10 ** 9 * float(sec_str))

--- a/examples/kitti/track_kitti_slam.py
+++ b/examples/kitti/track_kitti_slam.py
@@ -157,7 +157,8 @@ rr.log("xyz", rr.Arrows3D(
     labels=['[x]', '[y]', '[z]']
 ), static=True)
 
-SLAM_SYNC_MODE = False  # async slam thread is enabled
+TRACKER_MODE = cuvslam.Tracker.Mode.OdometryWithSlamRealtime  # async slam thread is enabled
+SLAM_SYNC_MODE = TRACKER_MODE == cuvslam.Tracker.Mode.OdometryWithSlamOffline
 IDX = 700  # starting index of the sequence after localization
 max_wait_time = 10.0  # seconds
 
@@ -178,12 +179,12 @@ cameras[1].rig_from_camera.translation[0] = -intrinsics[1][0][3] / intrinsics[1]
 
 # Set Odometry and SLAM Configs and initialize the cuvslam tracker
 odom_cfg = cuvslam.Odometry.Config(
-    async_sba=False,
+    async_sba=not SLAM_SYNC_MODE,
     enable_final_landmarks_export=True,
     rectified_stereo_camera=True
 )
 slam_cfg = cuvslam.Slam.Config(sync_mode=SLAM_SYNC_MODE)
-tracker = cuvslam.Tracker(cuvslam.Rig(cameras), odom_cfg, slam_cfg)
+tracker = cuvslam.Tracker(cuvslam.Rig(cameras), TRACKER_MODE, odom_cfg, slam_cfg)
 
 # Get timestamps from times.txt file
 timestamps = [

--- a/examples/multicamera_edex/track_multicamera_r2b.py
+++ b/examples/multicamera_edex/track_multicamera_r2b.py
@@ -95,7 +95,7 @@ rig.cameras = cameras
 
 odom_cfg = vslam.Odometry.Config(enable_final_landmarks_export = True)
 
-tracker = vslam.Tracker(rig, odom_cfg)
+tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
 
 trajectory = []
 

--- a/examples/multicamera_edex/track_multicamera_tartan.py
+++ b/examples/multicamera_edex/track_multicamera_tartan.py
@@ -93,7 +93,7 @@ rig.cameras = cameras
 
 odom_cfg = vslam.Odometry.Config(enable_final_landmarks_export = True, rectified_stereo_camera=True)
 
-tracker = vslam.Tracker(rig, odom_cfg)
+tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
 
 trajectory = []
 

--- a/examples/multisensor/track_multisensor_tartan.py
+++ b/examples/multisensor/track_multisensor_tartan.py
@@ -115,7 +115,7 @@ odom_cfg = vslam.Odometry.Config(
     async_sba=False,
 )
 
-tracker = vslam.Tracker(rig, odom_cfg)
+tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 print(f"cuVSLAM Tracker initialized with odometry mode: {cfg.odometry_mode}"
       f"{' (IMU disabled)' if not use_imu else ''}")
 

--- a/examples/oak-d/run_stereo.py
+++ b/examples/oak-d/run_stereo.py
@@ -162,7 +162,7 @@ def main() -> None:
         enable_observations_export=True,
         rectified_stereo_camera=False
     )
-    tracker = vslam.Tracker(vslam.Rig(cameras), odom_cfg)
+    tracker = vslam.Tracker(vslam.Rig(cameras), vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
     # Create pipeline with the device
     pipeline = dai.Pipeline(device)

--- a/examples/orbbec/run_rgbd.py
+++ b/examples/orbbec/run_rgbd.py
@@ -157,7 +157,7 @@ def main() -> None:
     )
 
     # Initialize tracker and visualizer
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
     visualizer = RerunVisualizer(num_viz_cameras=NUM_VIZ_CAMERAS)
 
     frame_id = 0

--- a/examples/orbbec/run_stereo.py
+++ b/examples/orbbec/run_stereo.py
@@ -166,7 +166,7 @@ def main() -> None:
     )
 
     # Initialize tracker and visualizer
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
     visualizer = RerunVisualizer()
 
     frame_id = 0

--- a/examples/realsense/run_multicamera.py
+++ b/examples/realsense/run_multicamera.py
@@ -216,7 +216,7 @@ def main() -> None:
         enable_final_landmarks_export=True,
         rectified_stereo_camera=True
     )
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
     # Configure all devices
     configure_all_devices(pipelines, configs)

--- a/examples/realsense/run_multisensor.py
+++ b/examples/realsense/run_multisensor.py
@@ -213,7 +213,7 @@ def main() -> None:
         multisensor_settings=multisensor_settings,
         rectified_stereo_camera=False
     )
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
     video_pipe = rs.pipeline()
     video_config = rs.config()

--- a/examples/realsense/run_rgbd.py
+++ b/examples/realsense/run_rgbd.py
@@ -85,7 +85,7 @@ def main() -> None:
     rig = get_rs_stereo_rig(camera_params)
 
     # Initialize tracker and visualizer
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
 
     # Get device product line for setting a supporting resolution
     pipeline_wrapper = rs.pipeline_wrapper(pipeline)

--- a/examples/realsense/run_stereo.py
+++ b/examples/realsense/run_stereo.py
@@ -72,7 +72,7 @@ def main() -> None:
     rig = get_rs_stereo_rig(camera_params)
 
     # Initialize tracker and visualizer
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
     # Get device product line for setting a supporting resolution
     pipeline_wrapper = rs.pipeline_wrapper(pipeline)

--- a/examples/realsense/run_vio.py
+++ b/examples/realsense/run_vio.py
@@ -299,7 +299,7 @@ def main() -> None:
     rig = get_rs_vio_rig(camera_params)
 
     # Initialize tracker
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
 
     # Set up IR pipeline
     ir_pipe = rs.pipeline()

--- a/examples/tum/track_tum.py
+++ b/examples/tum/track_tum.py
@@ -100,7 +100,7 @@ odom_cfg = cuvslam.Odometry.Config(
 )
 
 # Initialize tracker
-tracker = cuvslam.Tracker(cuvslam.Rig([camera]), odom_cfg)
+tracker = cuvslam.Tracker(cuvslam.Rig([camera]), cuvslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
 
 frame_id = 0
 prev_timestamp = None

--- a/examples/zed/live/run_rgbd.py
+++ b/examples/zed/live/run_rgbd.py
@@ -63,7 +63,7 @@ def main():
     rig = get_zed_rgbd_rig(camera_info, RUN_STEREO)
 
     # Initialize tracker and visualizer
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
     visualizer = RerunVisualizer(num_viz_cameras=2+RUN_STEREO)
 
     # Create and set RuntimeParameters after opening the camera

--- a/examples/zed/live/run_stereo.py
+++ b/examples/zed/live/run_stereo.py
@@ -60,7 +60,7 @@ def main():
     rig = get_zed_stereo_rig(camera_info, raw = RAW)
 
     # Initialize tracker
-    tracker = vslam.Tracker(rig, odom_cfg)
+    tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyOffline, odom_cfg)
     visualizer = RerunVisualizer()
 
     # Create and set RuntimeParameters after opening the camera

--- a/examples/zed/recording/track_svo/track_svo.py
+++ b/examples/zed/recording/track_svo/track_svo.py
@@ -75,11 +75,13 @@ def init_cuvslam_from_zed(zed_calibration: sl.CalibrationParameters):
                                                  rectified_stereo_camera=True,
                                                  multicam_mode=cuvslam.Odometry.MulticameraMode.Performance)
     if enable_slam:
+        cu_mode = cuvslam.Tracker.Mode.OdometryWithSlamOffline
         cu_slam_cfg = cuvslam.Slam.Config(enable_reading_internals=True, map_cell_size=2,
                                                  sync_mode=True, max_map_size=10000)
     else:
+        cu_mode = cuvslam.Tracker.Mode.OdometryOnlyOffline
         cu_slam_cfg = None
-    return cuvslam.Tracker(cuvslam.Rig(cu_cameras), cu_odom_cfg, cu_slam_cfg)
+    return cuvslam.Tracker(cuvslam.Rig(cu_cameras), cu_mode, cu_odom_cfg, cu_slam_cfg)
 
 
 # Generate pseudo-random colour from integer identifier for visualization

--- a/libs/cuvslam/cuvslam2.h
+++ b/libs/cuvslam/cuvslam2.h
@@ -1064,7 +1064,7 @@ public:
     OdometryOnlyRealtime,
     /// Odometry only, bundle adjustment in the calling thread.
     OdometryOnlyOffline,
-    /// Odometry and SLAM, both on background threads.
+    /// Odometry in the calling thread, bundle adjustment and SLAM on background threads.
     OdometryWithSlamRealtime,
     /// Odometry and SLAM, both in the calling thread.
     OdometryWithSlamOffline,

--- a/libs/cuvslam/cuvslam2.h
+++ b/libs/cuvslam/cuvslam2.h
@@ -1027,9 +1027,9 @@ private:
 /**
  * @brief Visual odometry with optional SLAM, combined behind a single interface
  *
- * Tracker owns an Odometry instance and, when constructed with a non-null SLAM configuration,
- * a Slam instance. It runs the standard per-frame sequence for you: Odometry::Track(), then
- * Odometry::GetState() and Slam::Track() when odometry produced a pose, then Slam::GetPose().
+ * Tracker owns an Odometry instance and, in the SLAM modes, a Slam instance. It runs the standard
+ * per-frame sequence for you: Odometry::Track(), then Odometry::GetState() and Slam::Track() when
+ * odometry produced a pose, then Slam::GetPose().
  *
  * Everything Tracker does can be done by driving Odometry and Slam directly; use those when you
  * need full control over the two components. Tracker is the recommended entry point otherwise.
@@ -1048,6 +1048,29 @@ public:
   using ImageSet = Odometry::ImageSet;
 
   /**
+   * @brief What the tracker runs, and in which thread
+   *
+   * The mode states both decisions in one place: whether SLAM runs at all, and whether the bundle
+   * adjuster and SLAM get threads of their own. A realtime mode keeps Track() fast, at the cost of
+   * results that are still being refined after the call returns. An offline mode runs everything in
+   * the calling thread, so each Track() result is final and a run is reproducible.
+   *
+   * The mode does not change the configurations passed to the constructor; it has to agree with
+   * them. `Odometry::Config::async_sba` must be true in a realtime mode and false in an offline one,
+   * and `Slam::Config::sync_mode` the other way round. A mismatch is rejected at construction.
+   */
+  enum class Mode {
+    /// Odometry only, bundle adjustment on a background thread.
+    OdometryOnlyRealtime,
+    /// Odometry only, bundle adjustment in the calling thread.
+    OdometryOnlyOffline,
+    /// Odometry and SLAM, both on background threads.
+    OdometryWithSlamRealtime,
+    /// Odometry and SLAM, both in the calling thread.
+    OdometryWithSlamOffline,
+  };
+
+  /**
    * @brief Result of a single Track() call
    */
   struct TrackResult {
@@ -1061,18 +1084,28 @@ public:
   /**
    * @brief Construct a tracker
    *
-   * When `slam_config` is non-null, Tracker enables observation and landmark export on its own copy
-   * of `odometry_config`, because SLAM needs both. The configs passed by the caller are not modified.
+   * `mode` selects whether SLAM runs and whether the bundle adjuster and SLAM run on their own
+   * threads, and it must agree with the configurations: a realtime mode needs
+   * `Odometry::Config::async_sba == true` and `Slam::Config::sync_mode == false`, an offline mode
+   * needs the opposite. Tracker never rewrites those fields, so what you configure is what runs.
+   * Note that both default to the realtime values, so the offline modes need configs that say so.
+   *
+   * The one thing Tracker does set is export: in the SLAM modes it enables observation and landmark
+   * export on its own copy of `odometry_config`, because SLAM needs both. The configs passed by the
+   * caller are not modified.
    *
    * @param[in] rig               rig setup
+   * @param[in] mode              what to run, and whether to run it in the background
    * @param[in] odometry_config   odometry configuration
-   * @param[in] slam_config       optional SLAM configuration; pass nullptr (the default) to disable
-   * SLAM. `Slam::Config::gt_align_mode` is not supported by Tracker; use standalone Odometry and
-   * Slam instances for ground-truth-aligned map building.
+   * @param[in] slam_config       SLAM configuration, used only in the SLAM modes; nullptr (the
+   * default) means `Slam::GetDefaultConfig()`, which suits `Mode::OdometryWithSlamRealtime`. Must be
+   * nullptr in the odometry-only modes. `Slam::Config::gt_align_mode` is not supported by Tracker;
+   * use standalone Odometry and Slam instances for ground-truth-aligned map building.
    * @throws std::runtime_error if odometry or SLAM fails to initialize
-   * @throws std::invalid_argument if rig or configuration is invalid
+   * @throws std::invalid_argument if the rig or a configuration is invalid, if a configuration
+   * disagrees with `mode`, or if `slam_config` is given in an odometry-only mode
    */
-  explicit Tracker(const Rig& rig, const Odometry::Config& odometry_config = Odometry::GetDefaultConfig(),
+  explicit Tracker(const Rig& rig, Mode mode, const Odometry::Config& odometry_config = Odometry::GetDefaultConfig(),
                    const Slam::Config* slam_config = nullptr);
 
   /**
@@ -1094,8 +1127,8 @@ public:
    * Odometry poses stay in the same coordinate frame until a loss of tracking. SLAM poses jump when
    * a loop closure is detected and the pose graph is optimized; they are never adjusted
    * retroactively, so use GetSlam().GetAllSlamPoses() to get a smooth trajectory up to the latest
-   * frame. In asynchronous mode loop closure runs on a separate thread to keep Track() fast, so
-   * SLAM poses are not updated immediately.
+   * frame. In a realtime mode loop closure runs on a separate thread to keep Track() fast, so SLAM
+   * poses are not updated immediately.
    *
    * @param[in]  images     synchronized images, no more than the number of cameras in the rig
    * @param[in]  masks      (Optional) corresponding masks
@@ -1122,7 +1155,7 @@ public:
   /**
    * @brief Is SLAM enabled
    *
-   * @return true when the tracker was constructed with a SLAM configuration
+   * @return true when the tracker was constructed with one of the SLAM modes
    */
   bool IsSlamEnabled() const;
 

--- a/libs/cuvslam/test/tracker_test.cpp
+++ b/libs/cuvslam/test/tracker_test.cpp
@@ -31,6 +31,7 @@ using cuvslam::Odometry;
 using cuvslam::Rig;
 using cuvslam::Slam;
 using cuvslam::Tracker;
+using Mode = Tracker::Mode;
 
 static_assert(std::is_same_v<decltype(std::declval<Tracker&>().GetOdometry()), const Odometry&>);
 static_assert(std::is_same_v<decltype(std::declval<Tracker&>().GetSlam()), Slam&>);
@@ -57,7 +58,7 @@ Rig MakeStereoRig() {
 /// Checks that the rig is rejected as invalid, with a message naming the field that is at fault.
 testing::AssertionResult RejectedWith(const Rig& rig, std::string_view field) {
   try {
-    Tracker{rig};
+    Tracker{rig, Mode::OdometryOnlyRealtime};
   } catch (const std::invalid_argument& e) {
     if (std::string_view{e.what()}.find(field) != std::string_view::npos) {
       return testing::AssertionSuccess();
@@ -67,14 +68,16 @@ testing::AssertionResult RejectedWith(const Rig& rig, std::string_view field) {
   return testing::AssertionFailure() << "rig was accepted";
 }
 
-/// Run the bundler and SLAM in the calling thread so the tests do not depend on background workers.
-struct SyncConfig {
+/// The configs an offline mode demands: bundler and SLAM in the calling thread, so the tests do not
+/// depend on background workers. Tracker checks these rather than setting them, so every offline
+/// test has to spell them out.
+struct OfflineConfig {
   Odometry::Config odometry;
   Slam::Config slam;
 };
 
-SyncConfig MakeSyncConfig() {
-  SyncConfig cfg;
+OfflineConfig MakeOfflineConfig() {
+  OfflineConfig cfg;
   cfg.odometry.async_sba = false;
   cfg.slam.sync_mode = true;
   cfg.slam.enable_reading_internals = true;
@@ -108,8 +111,8 @@ private:
   int64_t timestamp_ns_{0};
 };
 
-TEST_F(TrackerTest, SlamIsDisabledByDefault) {
-  Tracker tracker{rig};
+TEST_F(TrackerTest, OdometryOnlyModeHasNoSlam) {
+  Tracker tracker{rig, Mode::OdometryOnlyRealtime};
 
   EXPECT_FALSE(tracker.IsSlamEnabled());
   EXPECT_THROW(tracker.GetSlam(), std::logic_error);
@@ -120,10 +123,52 @@ TEST_F(TrackerTest, SlamIsDisabledByDefault) {
 }
 
 TEST_F(TrackerTest, GtAlignModeRequiresManualDispatch) {
-  SyncConfig cfg = MakeSyncConfig();
+  OfflineConfig cfg = MakeOfflineConfig();
   cfg.slam.gt_align_mode = true;
 
-  EXPECT_THROW(Tracker(rig, cfg.odometry, &cfg.slam), std::invalid_argument);
+  EXPECT_THROW(Tracker(rig, Mode::OdometryWithSlamOffline, cfg.odometry, &cfg.slam), std::invalid_argument);
+}
+
+// The mode says what runs and where; the configs have to say the same thing, and Tracker leaves them
+// alone rather than quietly rewriting them to fit. The realtime cases below only construct, so they
+// still do not depend on what the background threads do.
+TEST_F(TrackerTest, RealtimeModeAcceptsDefaultConfigs) {
+  Tracker odometry_only{rig, Mode::OdometryOnlyRealtime};
+  EXPECT_FALSE(odometry_only.IsSlamEnabled());
+
+  Tracker with_slam{rig, Mode::OdometryWithSlamRealtime};
+  EXPECT_TRUE(with_slam.IsSlamEnabled());
+}
+
+TEST_F(TrackerTest, ModeAndSbaSettingMustAgree) {
+  Odometry::Config realtime;  // async_sba defaults to true
+  EXPECT_THROW(Tracker(rig, Mode::OdometryOnlyOffline, realtime), std::invalid_argument);
+
+  Odometry::Config offline = MakeOfflineConfig().odometry;
+  EXPECT_THROW(Tracker(rig, Mode::OdometryOnlyRealtime, offline), std::invalid_argument);
+}
+
+TEST_F(TrackerTest, ModeAndSlamSettingMustAgree) {
+  OfflineConfig cfg = MakeOfflineConfig();
+
+  Slam::Config async_slam = cfg.slam;
+  async_slam.sync_mode = false;
+  EXPECT_THROW(Tracker(rig, Mode::OdometryWithSlamOffline, cfg.odometry, &async_slam), std::invalid_argument);
+
+  // A realtime mode with no SLAM config takes Slam::GetDefaultConfig(), which is asynchronous and so
+  // agrees; a blocking one handed in explicitly does not.
+  Odometry::Config realtime;
+  EXPECT_THROW(Tracker(rig, Mode::OdometryWithSlamRealtime, realtime, &cfg.slam), std::invalid_argument);
+}
+
+TEST_F(TrackerTest, RejectsSlamConfigInOdometryOnlyMode) {
+  OfflineConfig cfg = MakeOfflineConfig();
+
+  EXPECT_THROW(Tracker(rig, Mode::OdometryOnlyOffline, cfg.odometry, &cfg.slam), std::invalid_argument);
+
+  Odometry::Config realtime;
+  Slam::Config slam;
+  EXPECT_THROW(Tracker(rig, Mode::OdometryOnlyRealtime, realtime, &slam), std::invalid_argument);
 }
 
 TEST_F(TrackerTest, RejectsNonFiniteCalibration) {
@@ -163,8 +208,8 @@ TEST_F(TrackerTest, StandaloneSlamChecksTheWholeRig) {
 }
 
 TEST_F(TrackerTest, TrackReturnsSlamPoseWhenEnabled) {
-  SyncConfig cfg = MakeSyncConfig();
-  Tracker tracker{rig, cfg.odometry, &cfg.slam};
+  OfflineConfig cfg = MakeOfflineConfig();
+  Tracker tracker{rig, Mode::OdometryWithSlamOffline, cfg.odometry, &cfg.slam};
 
   EXPECT_TRUE(tracker.IsSlamEnabled());
   EXPECT_NO_THROW(tracker.GetSlam());
@@ -177,13 +222,15 @@ TEST_F(TrackerTest, TrackReturnsSlamPoseWhenEnabled) {
   EXPECT_NO_THROW(tracker.GetSlam().GetSlamMetrics(metrics));
 }
 
-// A SLAM configuration must turn on the exports SLAM depends on, whatever the odometry config said.
+// A SLAM mode must turn on the exports SLAM depends on, whatever the odometry config said. The
+// exports are the one thing Tracker overrides rather than checks: SLAM cannot run without them, so
+// there is no caller intent to preserve.
 TEST_F(TrackerTest, SlamConfigEnablesRequiredExports) {
-  SyncConfig cfg = MakeSyncConfig();
+  OfflineConfig cfg = MakeOfflineConfig();
   cfg.odometry.enable_observations_export = false;
   cfg.odometry.enable_landmarks_export = false;
 
-  Tracker tracker{rig, cfg.odometry, &cfg.slam};
+  Tracker tracker{rig, Mode::OdometryWithSlamOffline, cfg.odometry, &cfg.slam};
   tracker.Track(NextFrame());
 
   EXPECT_NO_THROW(tracker.GetOdometry().GetLastObservations(0));
@@ -196,11 +243,11 @@ TEST_F(TrackerTest, SlamConfigEnablesRequiredExports) {
 
 // Without SLAM the exports stay as configured, which is what makes the test above meaningful.
 TEST_F(TrackerTest, ExportsStayDisabledWithoutSlam) {
-  SyncConfig cfg = MakeSyncConfig();
+  OfflineConfig cfg = MakeOfflineConfig();
   cfg.odometry.enable_observations_export = false;
   cfg.odometry.enable_landmarks_export = false;
 
-  Tracker tracker{rig, cfg.odometry};
+  Tracker tracker{rig, Mode::OdometryOnlyOffline, cfg.odometry};
   tracker.Track(NextFrame());
 
   EXPECT_THROW(tracker.GetOdometry().GetLastObservations(0), std::invalid_argument);
@@ -208,8 +255,8 @@ TEST_F(TrackerTest, ExportsStayDisabledWithoutSlam) {
 }
 
 TEST_F(TrackerTest, ExposesUnderlyingComponents) {
-  SyncConfig cfg = MakeSyncConfig();
-  Tracker tracker{rig, cfg.odometry, &cfg.slam};
+  OfflineConfig cfg = MakeOfflineConfig();
+  Tracker tracker{rig, Mode::OdometryWithSlamOffline, cfg.odometry, &cfg.slam};
 
   EXPECT_FALSE(tracker.GetOdometry().GetPrimaryCameras().empty());
 
@@ -225,8 +272,8 @@ TEST_F(TrackerTest, ExposesUnderlyingComponents) {
 // to match against, so the tracker legitimately reports no pose from the second frame onwards; this
 // test is about the moved-to tracker still owning working components, not about tracking success.
 TEST_F(TrackerTest, MoveKeepsComponentsUsable) {
-  SyncConfig cfg = MakeSyncConfig();
-  Tracker tracker{rig, cfg.odometry, &cfg.slam};
+  OfflineConfig cfg = MakeOfflineConfig();
+  Tracker tracker{rig, Mode::OdometryWithSlamOffline, cfg.odometry, &cfg.slam};
   tracker.Track(NextFrame());
 
   Tracker moved{std::move(tracker)};

--- a/libs/cuvslam/tracker.cpp
+++ b/libs/cuvslam/tracker.cpp
@@ -23,12 +23,73 @@ namespace cuvslam {
 
 namespace {
 
-Odometry::Config TrackerOdometryConfig(const Odometry::Config& odometry_config, const Slam::Config* slam_config) {
-  if (slam_config != nullptr && slam_config->gt_align_mode) {
-    throw std::invalid_argument{"Tracker does not support gt_align_mode; use standalone Odometry and Slam instances."};
+/// Does this mode run SLAM alongside odometry?
+bool SlamEnabled(Tracker::Mode mode) {
+  switch (mode) {
+    case Tracker::Mode::OdometryOnlyRealtime:
+    case Tracker::Mode::OdometryOnlyOffline:
+      return false;
+    case Tracker::Mode::OdometryWithSlamRealtime:
+    case Tracker::Mode::OdometryWithSlamOffline:
+      return true;
   }
+  throw std::invalid_argument{"Tracker: unknown Mode"};
+}
+
+/// Does this mode give the bundle adjuster and SLAM threads of their own?
+bool Realtime(Tracker::Mode mode) {
+  switch (mode) {
+    case Tracker::Mode::OdometryOnlyRealtime:
+    case Tracker::Mode::OdometryWithSlamRealtime:
+      return true;
+    case Tracker::Mode::OdometryOnlyOffline:
+    case Tracker::Mode::OdometryWithSlamOffline:
+      return false;
+  }
+  throw std::invalid_argument{"Tracker: unknown Mode"};
+}
+
+/// The SLAM configuration Tracker will use. An omitted one means the defaults.
+Slam::Config TrackerSlamConfig(const Slam::Config* slam_config) {
+  return slam_config != nullptr ? *slam_config : Slam::GetDefaultConfig();
+}
+
+/// Tracker runs the configs as written, so it has to turn away anything the mode contradicts.
+void CheckModeMatchesConfigs(Tracker::Mode mode, const Odometry::Config& odometry_config,
+                             const Slam::Config* slam_config) {
+  const bool background = Realtime(mode);
+
+  if (odometry_config.async_sba != background) {
+    throw std::invalid_argument{
+        "Tracker: mode and Odometry::Config::async_sba disagree. A realtime mode requires async_sba == true, an "
+        "offline mode requires async_sba == false."};
+  }
+
+  if (SlamEnabled(mode)) {
+    const bool blocking_slam = !background;
+    const Slam::Config slam = TrackerSlamConfig(slam_config);
+    if (slam.sync_mode != blocking_slam) {
+      throw std::invalid_argument{
+          "Tracker: mode and Slam::Config::sync_mode disagree. A realtime mode requires sync_mode == false, an "
+          "offline mode requires sync_mode == true."};
+    }
+    if (slam.gt_align_mode) {
+      throw std::invalid_argument{
+          "Tracker does not support gt_align_mode; use standalone Odometry and Slam instances."};
+    }
+  } else if (slam_config != nullptr) {
+    throw std::invalid_argument{
+        "Tracker: slam_config must be null in an odometry-only mode; pick an OdometryWithSlam mode to enable SLAM."};
+  }
+}
+
+/// The odometry configuration Tracker will use: the caller's, plus the exports SLAM cannot run without.
+Odometry::Config TrackerOdometryConfig(Tracker::Mode mode, const Odometry::Config& odometry_config,
+                                       const Slam::Config* slam_config) {
+  CheckModeMatchesConfigs(mode, odometry_config, slam_config);
+
   Odometry::Config odometry = odometry_config;
-  if (slam_config != nullptr) {
+  if (SlamEnabled(mode)) {
     odometry.enable_observations_export = true;
     odometry.enable_landmarks_export = true;
   }
@@ -37,10 +98,10 @@ Odometry::Config TrackerOdometryConfig(const Odometry::Config& odometry_config, 
 
 }  // namespace
 
-Tracker::Tracker(const Rig& rig, const Odometry::Config& odometry_config, const Slam::Config* slam_config)
-    : odometry_{rig, TrackerOdometryConfig(odometry_config, slam_config)} {
-  if (slam_config != nullptr) {
-    slam_ = std::make_unique<Slam>(rig, odometry_.GetPrimaryCameras(), *slam_config);
+Tracker::Tracker(const Rig& rig, Mode mode, const Odometry::Config& odometry_config, const Slam::Config* slam_config)
+    : odometry_{rig, TrackerOdometryConfig(mode, odometry_config, slam_config)} {
+  if (SlamEnabled(mode)) {
+    slam_ = std::make_unique<Slam>(rig, odometry_.GetPrimaryCameras(), TrackerSlamConfig(slam_config));
   }
 }
 

--- a/python/cuvslam2.cpp
+++ b/python/cuvslam2.cpp
@@ -1117,7 +1117,7 @@ NB_MODULE(pycuvslam, m) {
       .value("OdometryOnlyOffline", Tracker::Mode::OdometryOnlyOffline,
              "Odometry only, bundle adjustment in the calling thread, so every `track()` result is final.")
       .value("OdometryWithSlamRealtime", Tracker::Mode::OdometryWithSlamRealtime,
-             "Odometry and SLAM, both on background threads.")
+             "Odometry in the calling thread, bundle adjustment and SLAM on background threads.")
       .value("OdometryWithSlamOffline", Tracker::Mode::OdometryWithSlamOffline,
              "Odometry and SLAM, both in the calling thread, which makes a run reproducible.");
 

--- a/python/cuvslam2.cpp
+++ b/python/cuvslam2.cpp
@@ -1111,22 +1111,42 @@ NB_MODULE(pycuvslam, m) {
                                          "Submit frames and IMU measurements through this class. Use the `odometry` "
                                          "and `slam` properties for module-specific queries and operations.");
 
+  nb::enum_<Tracker::Mode>(tracker_cls, "Mode", "What the tracker runs, and in which thread")
+      .value("OdometryOnlyRealtime", Tracker::Mode::OdometryOnlyRealtime,
+             "Odometry only, bundle adjustment on a background thread.")
+      .value("OdometryOnlyOffline", Tracker::Mode::OdometryOnlyOffline,
+             "Odometry only, bundle adjustment in the calling thread, so every `track()` result is final.")
+      .value("OdometryWithSlamRealtime", Tracker::Mode::OdometryWithSlamRealtime,
+             "Odometry and SLAM, both on background threads.")
+      .value("OdometryWithSlamOffline", Tracker::Mode::OdometryWithSlamOffline,
+             "Odometry and SLAM, both in the calling thread, which makes a run reproducible.");
+
   tracker_cls
       .def(
           "__init__",
-          [](Tracker* self, const Rig& rig, const std::optional<Odometry::Config>& odom_config,
+          [](Tracker* self, const Rig& rig, Tracker::Mode mode, const std::optional<Odometry::Config>& odom_config,
              const std::optional<Slam::Config>& slam_config) {
             // An omitted config means the Python default, which is not the C++ default.
             const Odometry::Config odometry_config = odom_config.value_or(PyDefaultOdometryConfig());
-            new (self) Tracker(rig, odometry_config, slam_config.has_value() ? &*slam_config : nullptr);
+            new (self) Tracker(rig, mode, odometry_config, slam_config.has_value() ? &*slam_config : nullptr);
           },
-          nb::arg("rig"), nb::arg("odom_config") = nb::none(), nb::arg("slam_config") = nb::none(),
+          nb::arg("rig"), nb::arg("mode"), nb::arg("odom_config") = nb::none(), nb::arg("slam_config") = nb::none(),
           "Initialize the cuVSLAM system. Each `Odometry.OdometryMode` has specific `rig` requirements.\n\n"
+          "`mode` picks whether SLAM runs and whether the bundle adjuster and SLAM get threads of their own. It has "
+          "to agree with the configurations: a realtime mode needs `odom_config.async_sba == True` and "
+          "`slam_config.sync_mode == False`, an offline mode needs the opposite. The tracker checks these rather than "
+          "changing them, so what you configure is what runs. Both fields default to the realtime values, so the "
+          "offline modes need configurations that say so.\n\n"
           "Parameters:\n"
           "    rig: Camera rig configuration\n"
+          "    mode: What to run, and whether to run it in the background, see :class:`cuvslam.Tracker.Mode`\n"
           "    odom_config: Optional odometry configuration (uses defaults if omitted)\n"
-          "    slam_config: Optional SLAM configuration (disables SLAM if None). `gt_align_mode` requires standalone "
-          "Odometry and Slam instances.")
+          "    slam_config: SLAM configuration, used only in the SLAM modes; None uses the SLAM defaults, which suit "
+          "`Mode.OdometryWithSlamRealtime`. Must be None in the odometry-only modes. `gt_align_mode` requires "
+          "standalone Odometry and Slam instances.\n\n"
+          "Raises:\n"
+          "    ValueError: If the rig is invalid, if a configuration disagrees with `mode`, or if `slam_config` is "
+          "given in an odometry-only mode.")
       .def(
           "track",
           [](Tracker& self, int64_t timestamp, const std::vector<nb::ndarray<nb::ro>>& images,
@@ -1157,11 +1177,11 @@ NB_MODULE(pycuvslam, m) {
           "If after several calls of Track() visual odometry is not able to recover, then invalid pose will be "
           "returned.\n"
           "Odometry will output poses in the same coordinate frame until a loss of tracking.\n\n"
-          "To get SLAM poses, SLAM must be enabled in the constructor by providing a non-null `slam_config`.\n"
+          "To get SLAM poses, the tracker must be constructed with one of the `Mode.OdometryWithSlam*` modes.\n"
           "SLAM poses may have loop closure (LC) jumps when LC is detected and pose graph is optimized.\n"
           "SLAM poses cannot be adjusted retroactively, so use `slam.get_all_slam_poses()` to get a smooth "
           "trajectory up to the latest frame.\n"
-          "Also, in asynchronous mode, LC is done in a separate work thread to keep `track` call fast, so SLAM poses "
+          "Also, in a realtime mode, LC is done in a separate work thread to keep `track` call fast, so SLAM poses "
           "are not updated immediately.\n\n"
           "All cameras must be synchronized. If a camera rig provides 'almost synchronized' frames, the timestamps "
           "should be within 1 millisecond.\n\n"

--- a/python/test/test_bindings.py
+++ b/python/test/test_bindings.py
@@ -610,6 +610,22 @@ class TestBindings(unittest.TestCase):
         ]
         self.assertEqual(len(values), len(set(values)))
 
+    def test_tracker_mode_enum(self):
+        # Verify all exposed enum values exist
+        self.assertIsNotNone(vslam.Tracker.Mode.OdometryOnlyRealtime)
+        self.assertIsNotNone(vslam.Tracker.Mode.OdometryOnlyOffline)
+        self.assertIsNotNone(vslam.Tracker.Mode.OdometryWithSlamRealtime)
+        self.assertIsNotNone(vslam.Tracker.Mode.OdometryWithSlamOffline)
+
+        # Values should be distinct
+        values = [
+            vslam.Tracker.Mode.OdometryOnlyRealtime,
+            vslam.Tracker.Mode.OdometryOnlyOffline,
+            vslam.Tracker.Mode.OdometryWithSlamRealtime,
+            vslam.Tracker.Mode.OdometryWithSlamOffline,
+        ]
+        self.assertEqual(len(values), len(set(values)))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/test/test_image_format.py
+++ b/python/test/test_image_format.py
@@ -23,7 +23,7 @@ class TestImageFormat(unittest.TestCase):
         camera = vslam.Camera(size=(640, 480), focal=(320.0, 320.0),
                               principal=(320.0, 240.0))
         self.rig = vslam.Rig([camera])
-        self.tracker = vslam.Tracker(self.rig)
+        self.tracker = vslam.Tracker(self.rig, vslam.Tracker.Mode.OdometryOnlyRealtime)
         self.timestamp = 1000
 
     def test_valid_2d_mono_image(self):

--- a/python/test/test_map.py
+++ b/python/test/test_map.py
@@ -139,7 +139,7 @@ class TestMap(unittest.TestCase):
 
         # Configure tracker for map creation
         odom_cfg, slam_cfg, _ = self.get_localization_configs()
-        tracker = vslam.Tracker(self.rig, odom_cfg, slam_cfg)
+        tracker = vslam.Tracker(self.rig, vslam.Tracker.Mode.OdometryWithSlamOffline, odom_cfg, slam_cfg)
 
         subplots = None
 
@@ -187,7 +187,7 @@ class TestMap(unittest.TestCase):
         Returns True if localization was successful.
         """
         odom_cfg, slam_cfg, loc_settings = self.get_localization_configs()
-        tracker = vslam.Tracker(self.rig, odom_cfg, slam_cfg)
+        tracker = vslam.Tracker(self.rig, vslam.Tracker.Mode.OdometryWithSlamOffline, odom_cfg, slam_cfg)
 
         images, z = img.generate_zoomed_images(step)
         timestamp = step * 1_000_000

--- a/python/test/test_tracking.py
+++ b/python/test/test_tracking.py
@@ -22,6 +22,8 @@ os.environ.setdefault("RERUN", "0")
 import cuvslam as vslam
 import data_gen as data
 
+TrackerMode = vslam.Tracker.Mode
+
 class TestTracking(unittest.TestCase):
     def setUp(self):
         cameras = data.generate_stereo_camera(640, 480, baseline=0.25)
@@ -31,43 +33,74 @@ class TestTracking(unittest.TestCase):
 
     def test_init_arguments(self):
         # accept partial, positional & keyword arguments
-        _ = vslam.Tracker(self.rig, vslam.Odometry.Config())
-        _ = vslam.Tracker(self.rig)
-        _ = vslam.Tracker(rig=self.rig, odom_config=vslam.Odometry.Config())
-        _ = vslam.Tracker(rig=self.rig)
-        _ = vslam.Tracker(rig=self.rig, slam_config=vslam.Slam.Config())
+        _ = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, vslam.Odometry.Config())
+        _ = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime)
+        _ = vslam.Tracker(rig=self.rig, mode=TrackerMode.OdometryOnlyRealtime,
+                          odom_config=vslam.Odometry.Config())
+        _ = vslam.Tracker(rig=self.rig, mode=TrackerMode.OdometryOnlyRealtime)
+        _ = vslam.Tracker(rig=self.rig, mode=TrackerMode.OdometryWithSlamRealtime,
+                          slam_config=vslam.Slam.Config())
 
         with self.assertRaises(TypeError):
             vslam.Tracker()  # type: ignore # missing required argument "rig"
 
+        with self.assertRaises(TypeError):
+            vslam.Tracker(self.rig)  # type: ignore # missing required argument "mode"
+
     def test_component_accessors(self):
-        tracker = vslam.Tracker(self.rig)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime)
         self.assertIsInstance(tracker.odometry, vslam.Odometry)
         self.assertFalse(tracker.is_slam_enabled())
         with self.assertRaisesRegex(RuntimeError, "SLAM is not enabled"):
             _ = tracker.slam
 
-        tracker_with_slam = vslam.Tracker(self.rig, slam_config=vslam.Slam.Config())
+        tracker_with_slam = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamRealtime,
+                                          slam_config=vslam.Slam.Config())
         self.assertTrue(tracker_with_slam.is_slam_enabled())
         self.assertIsInstance(tracker_with_slam.slam, vslam.Slam)
+
+    def test_init_mode_must_match_configs(self):
+        # The mode and the configurations have to say the same thing. The tracker checks them
+        # instead of rewriting them, so a disagreement is an error rather than a silent override.
+        offline = vslam.Odometry.Config(async_sba=False)
+        blocking_slam = vslam.Slam.Config(sync_mode=True)
+
+        with self.assertRaisesRegex(ValueError, "async_sba"):
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyOffline, vslam.Odometry.Config())
+        with self.assertRaisesRegex(ValueError, "async_sba"):
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, offline)
+
+        with self.assertRaisesRegex(ValueError, "sync_mode"):
+            vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, offline, vslam.Slam.Config())
+        with self.assertRaisesRegex(ValueError, "sync_mode"):
+            vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamRealtime,
+                          vslam.Odometry.Config(), blocking_slam)
+
+        # A SLAM configuration is meaningless without a SLAM mode.
+        with self.assertRaisesRegex(ValueError, "slam_config must be null"):
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyOffline, offline, blocking_slam)
+
+        # The combinations that agree are accepted.
+        _ = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyOffline, offline)
+        _ = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, offline, blocking_slam)
 
     @unittest.skip("TODO: add a check that cameras don't have the same pose")
     def test_init_same_cameras(self):
         # don't accept rig with duplicate cameras
         bad_rig = vslam.Rig(cameras=[self.rig.cameras[0], self.rig.cameras[0]])
         with self.assertRaises(ValueError):
-            vslam.Tracker(bad_rig)
+            vslam.Tracker(bad_rig, TrackerMode.OdometryOnlyRealtime)
 
     def test_init_no_cameras(self):
         # don't accept empty rig with no cameras
         with self.assertRaises(ValueError):
-            vslam.Tracker(vslam.Rig([]))
+            vslam.Tracker(vslam.Rig([]), TrackerMode.OdometryOnlyRealtime)
 
     def test_init_different_sizes(self):
         # don't accept cameras with different sizes
         self.rig.cameras[1].size[0] = 480
         with self.assertRaises(ValueError):
-            vslam.Tracker(self.rig)
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime)
 
     def test_init_inertial_no_imus(self):
         # don't accept rig with no IMUs in inertial mode
@@ -75,7 +108,7 @@ class TestTracking(unittest.TestCase):
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Inertial
         with self.assertRaises(ValueError):
-            vslam.Tracker(self.rig, cfg)
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, cfg)
 
     def test_init_multiple_imus(self):
         # don't accept rig with multiple IMUs
@@ -83,14 +116,14 @@ class TestTracking(unittest.TestCase):
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Inertial
         with self.assertRaises(ValueError):
-            vslam.Tracker(self.rig)
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime)
 
     def test_init_negative_image_size(self):
         # image sizes should be positive
         self.rig.cameras[0].size[0] = -1
         self.rig.cameras[1].size[0] = -1
         with self.assertRaises(ValueError):
-            vslam.Tracker(self.rig)
+            vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime)
 
     def test_tracking(self):
         modes = [vslam.Odometry.OdometryMode.Multicamera, vslam.Odometry.OdometryMode.Inertial,
@@ -108,7 +141,7 @@ class TestTracking(unittest.TestCase):
                     cfg.rgbd_settings.depth_scale_factor = 1000.0
                     cfg.rgbd_settings.depth_camera_id = 0
                     cfg.rgbd_settings.enable_depth_stereo_tracking = False
-                    tracker = vslam.Tracker(self.rig, cfg)
+                    tracker = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, cfg)
                     for i in range(60):
                         # Add 10 IMU measurements between frames
                         if mode == vslam.Odometry.OdometryMode.Inertial:
@@ -147,7 +180,7 @@ class TestTracking(unittest.TestCase):
                 multisensor_settings=vslam.Odometry.MultisensorSettings(
                     depth_camera_ids=[0], depth_scale_factor=1000.0))
             rig = vslam.Rig([self.rig.cameras[0]])
-            tracker = vslam.Tracker(rig, config)
+            tracker = vslam.Tracker(rig, TrackerMode.OdometryOnlyRealtime, config)
             tracker.track(1000, [image], depths=[depth])
             tracker.track(2000, [image], depths=[depth])
 
@@ -155,7 +188,7 @@ class TestTracking(unittest.TestCase):
             config = vslam.Odometry.Config(
                 odometry_mode=vslam.Odometry.OdometryMode.Multisensor)
             rig = vslam.Rig(self.rig.cameras)
-            tracker = vslam.Tracker(rig, config)
+            tracker = vslam.Tracker(rig, TrackerMode.OdometryOnlyRealtime, config)
             stereo_images = [image.copy(), image.copy()]
             tracker.track(1000, stereo_images)
             tracker.track(2000, stereo_images)
@@ -166,7 +199,7 @@ class TestTracking(unittest.TestCase):
                 multisensor_settings=vslam.Odometry.MultisensorSettings(
                     depth_camera_ids=[0], depth_scale_factor=1000.0))
             rig = vslam.Rig([self.rig.cameras[0]], [vslam.ImuCalibration()])
-            tracker = vslam.Tracker(rig, config)
+            tracker = vslam.Tracker(rig, TrackerMode.OdometryOnlyRealtime, config)
             for frame in range(2):
                 frame_start_ns = frame * 1100
                 for sample in range(10):
@@ -182,7 +215,7 @@ class TestTracking(unittest.TestCase):
             odometry_mode=vslam.Odometry.OdometryMode.Multisensor)
         rig = vslam.Rig([self.rig.cameras[0]])
         with self.assertRaisesRegex(ValueError, "at least one RGB-D camera.*or one camera pair"):
-            vslam.Tracker(rig, config)
+            vslam.Tracker(rig, TrackerMode.OdometryOnlyRealtime, config)
 
     def test_multisensor_rejects_duplicate_depth_camera_ids(self):
         config = vslam.Odometry.Config(
@@ -191,7 +224,7 @@ class TestTracking(unittest.TestCase):
                 depth_camera_ids=[0, 0]))
         rig = vslam.Rig([self.rig.cameras[0]])
         with self.assertRaisesRegex(ValueError, "duplicate camera id"):
-            vslam.Tracker(rig, config)
+            vslam.Tracker(rig, TrackerMode.OdometryOnlyRealtime, config)
 
     def _run_keyframe_overrides(self, mode, overrides):
         """Track a fixed feature-rich frame repeatedly, applying a per-frame keyframe override.
@@ -270,7 +303,7 @@ class TestTracking(unittest.TestCase):
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
         cfg.enable_observations_export = True
         cfg.enable_landmarks_export = True
-        tracker = vslam.Tracker(self.rig, cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, cfg)
 
         # Track a few frames to build up features
         for i in range(5):
@@ -299,7 +332,7 @@ class TestTracking(unittest.TestCase):
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
         cfg.enable_final_landmarks_export = True
-        tracker = vslam.Tracker(self.rig, cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, cfg)
 
         for i in range(5):
             images, _ = img.generate_zoomed_images(i)
@@ -311,7 +344,7 @@ class TestTracking(unittest.TestCase):
     def test_get_gravity_non_inertial(self):
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
-        tracker = vslam.Tracker(self.rig, cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryOnlyRealtime, cfg)
 
         images = [np.zeros((480, 640), dtype=np.uint8) for _ in range(self.num_cameras)]
         tracker.track(1000, images)
@@ -325,9 +358,10 @@ class TestTracking(unittest.TestCase):
 
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
+        cfg.async_sba = False
         s_cfg = vslam.Slam.Config()
         s_cfg.sync_mode = True
-        tracker = vslam.Tracker(self.rig, cfg, s_cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, cfg, s_cfg)
 
         for i in range(3):
             images, _ = img.generate_zoomed_images(i)
@@ -343,9 +377,10 @@ class TestTracking(unittest.TestCase):
 
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
+        cfg.async_sba = False
         s_cfg = vslam.Slam.Config()
         s_cfg.sync_mode = True
-        tracker = vslam.Tracker(self.rig, cfg, s_cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, cfg, s_cfg)
 
         for i in range(3):
             images, _ = img.generate_zoomed_images(i)
@@ -360,9 +395,10 @@ class TestTracking(unittest.TestCase):
 
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
+        cfg.async_sba = False
         s_cfg = vslam.Slam.Config()
         s_cfg.sync_mode = True
-        tracker = vslam.Tracker(self.rig, cfg, s_cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, cfg, s_cfg)
 
         for i in range(5):
             images, _ = img.generate_zoomed_images(i)
@@ -379,10 +415,11 @@ class TestTracking(unittest.TestCase):
 
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
+        cfg.async_sba = False
         s_cfg = vslam.Slam.Config()
         s_cfg.sync_mode = True
         s_cfg.enable_reading_internals = True
-        tracker = vslam.Tracker(self.rig, cfg, s_cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, cfg, s_cfg)
 
         for i in range(5):
             images, _ = img.generate_zoomed_images(i)
@@ -398,10 +435,11 @@ class TestTracking(unittest.TestCase):
 
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
+        cfg.async_sba = False
         s_cfg = vslam.Slam.Config()
         s_cfg.sync_mode = True
         s_cfg.enable_reading_internals = True
-        tracker = vslam.Tracker(self.rig, cfg, s_cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, cfg, s_cfg)
 
         for i in range(5):
             images, _ = img.generate_zoomed_images(i)
@@ -419,10 +457,11 @@ class TestTracking(unittest.TestCase):
         cfg = vslam.Odometry.Config()
         cfg.odometry_mode = vslam.Odometry.OdometryMode.Multicamera
 
+        cfg.async_sba = False
         s_cfg = vslam.Slam.Config()
         s_cfg.sync_mode = True
 
-        tracker = vslam.Tracker(self.rig, cfg, s_cfg)
+        tracker = vslam.Tracker(self.rig, TrackerMode.OdometryWithSlamOffline, cfg, s_cfg)
 
         identity = vslam.Pose(translation=[0.0, 0.0, 0.0], rotation=[0.0, 0.0, 0.0, 1.0])
         odom_pose, slam_pose = tracker.track(1000, synthetic_images)

--- a/tools/python/hello_world_cuvslam.py
+++ b/tools/python/hello_world_cuvslam.py
@@ -30,7 +30,7 @@ for i in range(2):
 rig = vslam.Rig(cameras=cameras, imus=[])
 # Create a tracker with horizontal (rectified) stereo camera; SLAM is disabled.
 odom_cfg = vslam.Odometry.Config(rectified_stereo_camera=True)
-tracker = vslam.Tracker(rig, odom_cfg)
+tracker = vslam.Tracker(rig, vslam.Tracker.Mode.OdometryOnlyRealtime, odom_cfg)
 
 print("cuVSLAM version:", vslam.get_version())
 print("Odometry.Config:")

--- a/tools/python_tools/cuvslam_tools/tracker/cli.py
+++ b/tools/python_tools/cuvslam_tools/tracker/cli.py
@@ -135,7 +135,8 @@ def add_tracker_arguments(parser: argparse.ArgumentParser) -> None:
         "--async_sba",
         type=_str2bool,
         default=False,
-        help="Enable asynchronous Sparse Bundle Adjustment.",
+        help="Enable asynchronous Sparse Bundle Adjustment. Selects the realtime tracker mode, "
+             "in which case --sync_slam must be false.",
     )
     parser.add_argument(
         "--use_motion_model",
@@ -192,7 +193,8 @@ def add_tracker_arguments(parser: argparse.ArgumentParser) -> None:
         help="Enable IMU debug mode.",
     )
     parser.add_argument("--use_slam", type=_str2bool, default=False, help="Enable SLAM mode.")
-    parser.add_argument("--sync_slam", type=_str2bool, default=True, help="Use synchronous SLAM.")
+    parser.add_argument("--sync_slam", type=_str2bool, default=True,
+                        help="Run SLAM in the calling thread. Must be the opposite of --async_sba.")
 
     parser.add_argument(
         "--depth_scale_factor",

--- a/tools/python_tools/cuvslam_tools/tracker/runner.py
+++ b/tools/python_tools/cuvslam_tools/tracker/runner.py
@@ -112,9 +112,12 @@ class Tracker:
             if args.visualize_rerun:
                 self.slam_cfg.enable_reading_internals = True
 
+        self.mode = self._tracker_mode(self.slam_cfg is not None, self.odom_cfg.async_sba)
+
         if args.print_config:
             print(
                 f"cuVSLAM version: {vslam.get_version()}\n"
+                f"Tracker mode: {self.mode}\n"
                 f"Odometry config:\n{conv.to_str(self.odom_cfg)}"
             )
             if self.slam_cfg:
@@ -122,7 +125,7 @@ class Tracker:
 
         self.stat = Stat()
         self.stat.odometry_mode = str(self.odom_cfg.odometry_mode)
-        self.tracker = vslam.Tracker(rig, self.odom_cfg, self.slam_cfg)
+        self.tracker = vslam.Tracker(rig, self.mode, self.odom_cfg, self.slam_cfg)
 
         self.frame_id_from_ts = {}
         self.world_from_rig = {}
@@ -140,6 +143,19 @@ class Tracker:
                 not self.odom_cfg.enable_landmarks_export and
                 not self.odom_cfg.enable_final_landmarks_export ):
                 print("Exporting landmarks or observations is disabled, skipping visualization in Rerun")
+
+    @staticmethod
+    def _tracker_mode(use_slam: bool, async_sba: bool) -> vslam.Tracker.Mode:
+        """Pick the tracker mode from --use_slam and --async_sba.
+
+        --sync_slam has to be the opposite of --async_sba; the Tracker constructor rejects the
+        combinations that disagree, so the rule lives in one place.
+        """
+        if use_slam:
+            return (vslam.Tracker.Mode.OdometryWithSlamRealtime if async_sba
+                    else vslam.Tracker.Mode.OdometryWithSlamOffline)
+        return (vslam.Tracker.Mode.OdometryOnlyRealtime if async_sba
+                else vslam.Tracker.Mode.OdometryOnlyOffline)
 
     def configure_tracker(self, args: argparse.Namespace) -> None:
         """Configure tracker with default and user settings"""


### PR DESCRIPTION
Tracker's constructor now takes a required Tracker::Mode as its second argument: OdometryOnlyRealtime, OdometryOnlyOffline, OdometryWithSlamRealtime or OdometryWithSlamOffline. The mode states in one place whether SLAM runs and whether the bundle adjuster and SLAM run on their own threads, which previously had to be inferred from a nullable slam_config plus two unrelated configuration fields.

The mode has to agree with those fields rather than replace them. Tracker checks Odometry::Config::async_sba and Slam::Config::sync_mode against the mode and throws std::invalid_argument on a mismatch, so a configuration is never silently rewritten behind the caller's back. A slam_config given in an odometry-only mode is rejected for the same reason. Both fields default to the realtime values, so the offline modes need configurations that say so. The observation and landmark exports stay an override: SLAM cannot run without them, so there is no caller intent to preserve.

Call sites take the mode matching the async_sba they already set, so behaviour is unchanged, with one exception. examples/kitti/track_kitti_slam.py ran blocking SBA with an asynchronous SLAM thread, which no mode expresses; it moves to OdometryWithSlamRealtime, since the example exists to demonstrate asynchronous localization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit tracker modes for odometry-only or SLAM operation in realtime or offline execution.
  * Tracker construction now requires a selected mode and validates compatible configuration settings.
  * Invalid combinations, including SLAM configuration in odometry-only modes, are rejected with clear errors.
  * Updated tools and examples to select and display the appropriate tracker mode.

* **Documentation**
  * Expanded troubleshooting, CLI help, tutorials, and onboarding guidance for mode and configuration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->