### PR TITLE
[fix] Read report Git provenance inside the eval container

### DIFF
--- a/scripts/run_eval.sh
+++ b/scripts/run_eval.sh
@@ -18,6 +18,14 @@ if [ ! -d "$OUTPUT_DIR/build" ]; then
   exit 1
 fi
 
+# The source tree is bind-mounted from the host while this container runs as root, so
+# Git rejects it as dubiously owned. Allow-list it so the reporter can read the commit
+# SHA, branch, and commit date for the report header. Provenance is not worth failing
+# the evaluation over, so a missing or unusable Git only downgrades those fields.
+if ! git config --global --add safe.directory /cuvslam; then
+  echo "Warning: could not mark /cuvslam as a safe Git directory; report provenance will be unknown"
+fi
+
 EVAL_STATS="$OUTPUT_DIR/eval/stats"
 mkdir -p "$EVAL_STATS"
 [ "$WRITE_HISTORY" = "true" ] && mkdir -p "$KPI_HISTORY"

--- a/tools/python_tools/cuvslam_tools/reporter/generate_report.py
+++ b/tools/python_tools/cuvslam_tools/reporter/generate_report.py
@@ -223,9 +223,9 @@ def _git_output(args: List[str], repo_dir: str) -> Tuple[str, str]:
 def _git_source_metadata(repo_dir: str) -> Tuple[str, str, str, str]:
     """Return (commit_sha, branch_name, commit_timestamp, warning) describing repo_dir.
 
-    The warning is empty once provenance resolves. Otherwise it explains why the three
-    fields are unknown, so the report carries the reason too; reports are published as
-    an artifact of their own and are read without the run log next to them.
+    The warning is empty only when every field resolved. Otherwise it explains why the
+    unknown ones are unknown, so the report carries the reason too; reports are published
+    as an artifact of their own and are read without the run log next to them.
     """
     commit_sha, error = _git_output(['rev-parse', 'HEAD'], repo_dir)
     if not commit_sha:
@@ -233,9 +233,20 @@ def _git_source_metadata(repo_dir: str) -> Tuple[str, str, str, str]:
         print(f"Warning: {warning}")
         return "unknown", "unknown", "unknown", warning
 
-    branch_name, _ = _git_output(['rev-parse', '--abbrev-ref', 'HEAD'], repo_dir)
-    commit_ts, _ = _git_output(['show', '-s', '--format=%ci', commit_sha], repo_dir)
-    return commit_sha, branch_name or "unknown", commit_ts.replace(' ', '/') or "unknown", ""
+    branch_name, branch_error = _git_output(['rev-parse', '--abbrev-ref', 'HEAD'], repo_dir)
+    commit_ts, commit_ts_error = _git_output(['show', '-s', '--format=%ci', commit_sha], repo_dir)
+
+    warning = ""
+    failures = []
+    if branch_error:
+        failures.append(f"branch name: {branch_error}")
+    if commit_ts_error:
+        failures.append(f"commit date: {commit_ts_error}")
+    if failures:
+        warning = f"Provenance incomplete for {repo_dir}: {'; '.join(failures)}"
+        print(f"Warning: {warning}")
+
+    return commit_sha, branch_name or "unknown", commit_ts.replace(' ', '/') or "unknown", warning
 
 
 def generate_report(test_folder, comments, stats, generate_pdf=False, config_name=None):

--- a/tools/python_tools/cuvslam_tools/reporter/generate_report.py
+++ b/tools/python_tools/cuvslam_tools/reporter/generate_report.py
@@ -220,21 +220,29 @@ def _git_output(args: List[str], repo_dir: str) -> Tuple[str, str]:
     return completed.stdout.strip(), ""
 
 
-def _git_source_metadata(repo_dir: str) -> Tuple[str, str, str]:
-    """Return (commit_sha, branch_name, commit_timestamp) describing repo_dir."""
+def _git_source_metadata(repo_dir: str) -> Tuple[str, str, str, str]:
+    """Return (commit_sha, branch_name, commit_timestamp, warning) describing repo_dir.
+
+    The warning is empty once provenance resolves. Otherwise it explains why the three
+    fields are unknown, so the report carries the reason too; reports are published as
+    an artifact of their own and are read without the run log next to them.
+    """
     commit_sha, error = _git_output(['rev-parse', 'HEAD'], repo_dir)
     if not commit_sha:
-        print(f"Warning: report provenance unavailable for {repo_dir}: {error}")
-        return "unknown", "unknown", "unknown"
+        warning = f"Provenance unavailable for {repo_dir}: {error}"
+        print(f"Warning: {warning}")
+        return "unknown", "unknown", "unknown", warning
 
     branch_name, _ = _git_output(['rev-parse', '--abbrev-ref', 'HEAD'], repo_dir)
     commit_ts, _ = _git_output(['show', '-s', '--format=%ci', commit_sha], repo_dir)
-    return commit_sha, branch_name or "unknown", commit_ts.replace(' ', '/') or "unknown"
+    return commit_sha, branch_name or "unknown", commit_ts.replace(' ', '/') or "unknown", ""
 
 
 def generate_report(test_folder, comments, stats, generate_pdf=False, config_name=None):
     """Generate an HTML report and optionally render a PDF copy."""
-    commit_sha, branch_name, commit_ts = _git_source_metadata(os.path.dirname(os.path.abspath(__file__)))
+    commit_sha, branch_name, commit_ts, provenance_warning = _git_source_metadata(
+        os.path.dirname(os.path.abspath(__file__))
+    )
 
     date_time = datetime.now().replace(microsecond=0).astimezone().isoformat('/')
 
@@ -287,6 +295,7 @@ def generate_report(test_folder, comments, stats, generate_pdf=False, config_nam
         branch_name=branch_name,
         commit_sha=commit_sha,
         commit_ts=commit_ts,
+        provenance_warning=provenance_warning,
         comments=comments,
         stats=stats_for_html,
         total=total,
@@ -327,6 +336,7 @@ def generate_report(test_folder, comments, stats, generate_pdf=False, config_nam
                 branch_name=branch_name,
                 commit_sha=commit_sha,
                 commit_ts=commit_ts,
+                provenance_warning=provenance_warning,
                 comments=comments,
                 stats=stats_for_pdf,
                 total=total,

--- a/tools/python_tools/cuvslam_tools/reporter/generate_report.py
+++ b/tools/python_tools/cuvslam_tools/reporter/generate_report.py
@@ -200,39 +200,41 @@ def _save_avg_error_plots(stats, plots_dir: str) -> Tuple[Optional[str], Optiona
     return avg_tl_path, avg_rl_path
 
 
+def _git_output(args: List[str], repo_dir: str) -> Tuple[str, str]:
+    """Run one git command in repo_dir and return (stdout, error_message).
+
+    Git output is captured rather than inherited so that a failed provenance query
+    cannot write to the log of whatever pipeline is running the reporter.
+    """
+    try:
+        completed = subprocess.run(
+            ['git', '-C', repo_dir] + args,
+            capture_output=True,
+            universal_newlines=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        return "", "git is not installed"
+    except subprocess.CalledProcessError as exc:
+        return "", " ".join((exc.stderr or "").split()) or f"git exited with {exc.returncode}"
+    return completed.stdout.strip(), ""
+
+
+def _git_source_metadata(repo_dir: str) -> Tuple[str, str, str]:
+    """Return (commit_sha, branch_name, commit_timestamp) describing repo_dir."""
+    commit_sha, error = _git_output(['rev-parse', 'HEAD'], repo_dir)
+    if not commit_sha:
+        print(f"Warning: report provenance unavailable for {repo_dir}: {error}")
+        return "unknown", "unknown", "unknown"
+
+    branch_name, _ = _git_output(['rev-parse', '--abbrev-ref', 'HEAD'], repo_dir)
+    commit_ts, _ = _git_output(['show', '-s', '--format=%ci', commit_sha], repo_dir)
+    return commit_sha, branch_name or "unknown", commit_ts.replace(' ', '/') or "unknown"
+
+
 def generate_report(test_folder, comments, stats, generate_pdf=False, config_name=None):
     """Generate an HTML report and optionally render a PDF copy."""
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-
-    # Get commit SHA
-    try:
-        commit_sha = subprocess.check_output(
-            ['git', 'rev-parse', 'HEAD'],
-            universal_newlines=True,
-            cwd=script_dir
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        commit_sha = "unknown"
-
-    # Get branch name
-    try:
-        branch_name = subprocess.check_output(
-            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
-            universal_newlines=True,
-            cwd=script_dir
-        ).strip()
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        branch_name = "unknown"
-
-    # Get commit timestamp
-    try:
-        commit_ts = subprocess.check_output(
-            ['git', 'show', '-s', '--format=%ci', commit_sha],
-            universal_newlines=True,
-            cwd=script_dir
-        ).strip().replace(' ', '/')
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        commit_ts = "unknown"
+    commit_sha, branch_name, commit_ts = _git_source_metadata(os.path.dirname(os.path.abspath(__file__)))
 
     date_time = datetime.now().replace(microsecond=0).astimezone().isoformat('/')
 

--- a/tools/python_tools/cuvslam_tools/reporter/report_templates/report.html
+++ b/tools/python_tools/cuvslam_tools/reporter/report_templates/report.html
@@ -64,6 +64,12 @@
         <td>Commit Date/Time</td>
         <td>{{commit_ts}}</td>
     </tr>
+    {% if provenance_warning %}
+    <tr class="summary">
+        <td>Provenance</td>
+        <td>{{provenance_warning}}</td>
+    </tr>
+    {% endif %}
     <tr class="summary">
         <td>Comments</td>
         <td>{{comments}}</td>

--- a/tools/python_tools/cuvslam_tools/reporter/report_templates/report_pdf.html
+++ b/tools/python_tools/cuvslam_tools/reporter/report_templates/report_pdf.html
@@ -89,6 +89,12 @@
         <td>Commit Date/Time</td>
         <td>{{commit_ts}}</td>
     </tr>
+    {% if provenance_warning %}
+    <tr class="summary">
+        <td>Provenance</td>
+        <td>{{provenance_warning}}</td>
+    </tr>
+    {% endif %}
     <tr class="summary">
         <td>Comments</td>
         <td>{{comments}}</td>

--- a/tools/python_tools/cuvslam_tools/tests/test_reporter_cli.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_reporter_cli.py
@@ -62,6 +62,29 @@ class TestGitSourceMetadata(unittest.TestCase):
         self.assertEqual((commit_sha, branch_name, commit_ts), ("unknown", "unknown", "unknown"))
         self.assertIn("git is not installed", warning)
 
+    def test_commit_date_failure_keeps_the_resolved_fields_and_the_reason(self):
+        error = subprocess.CalledProcessError(128, ["git", "show"])
+        error.stderr = "fatal: bad object HEAD\n"
+        with mock.patch.object(generate_report.subprocess, "run") as run:
+            run.side_effect = [mock.Mock(stdout="1234567890abcdef\n"), mock.Mock(stdout="feature/branch\n"), error]
+            commit_sha, branch_name, commit_ts, warning = generate_report._git_source_metadata("/cuvslam")
+
+        self.assertEqual((commit_sha, branch_name, commit_ts), ("1234567890abcdef", "feature/branch", "unknown"))
+        self.assertIn("commit date: fatal: bad object HEAD", warning)
+
+    def test_both_secondary_failures_are_reported(self):
+        branch_error = subprocess.CalledProcessError(128, ["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        branch_error.stderr = "fatal: no branch\n"
+        date_error = subprocess.CalledProcessError(128, ["git", "show"])
+        date_error.stderr = "fatal: bad object HEAD\n"
+        with mock.patch.object(generate_report.subprocess, "run") as run:
+            run.side_effect = [mock.Mock(stdout="1234567890abcdef\n"), branch_error, date_error]
+            commit_sha, branch_name, commit_ts, warning = generate_report._git_source_metadata("/cuvslam")
+
+        self.assertEqual((commit_sha, branch_name, commit_ts), ("1234567890abcdef", "unknown", "unknown"))
+        self.assertIn("branch name: fatal: no branch", warning)
+        self.assertIn("commit date: fatal: bad object HEAD", warning)
+
     def test_git_failure_is_not_written_to_the_process_log(self):
         """A directory outside any repository must not leak git's fatal error to stderr."""
         script = (

--- a/tools/python_tools/cuvslam_tools/tests/test_reporter_cli.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_reporter_cli.py
@@ -44,27 +44,29 @@ class TestGitSourceMetadata(unittest.TestCase):
             run.side_effect = [mock.Mock(stdout=f"{value}\n") for value in outputs]
             metadata = generate_report._git_source_metadata("/cuvslam")
 
-        self.assertEqual(metadata, ("1234567890abcdef", "feature/branch", "2026-08-31/17:08:04/+0000"))
+        self.assertEqual(metadata, ("1234567890abcdef", "feature/branch", "2026-08-31/17:08:04/+0000", ""))
 
-    def test_unreadable_repository_degrades_to_unknown(self):
+    def test_unreadable_repository_degrades_to_unknown_with_a_reason(self):
         error = subprocess.CalledProcessError(128, ["git", "rev-parse", "HEAD"])
-        error.stderr = "fatal: detected dubious ownership in repository at '/cuvslam'\n"
+        error.stderr = "fatal: detected dubious ownership in repository at /cuvslam\n"
         with mock.patch.object(generate_report.subprocess, "run", side_effect=error):
-            metadata = generate_report._git_source_metadata("/cuvslam")
+            commit_sha, branch_name, commit_ts, warning = generate_report._git_source_metadata("/cuvslam")
 
-        self.assertEqual(metadata, ("unknown", "unknown", "unknown"))
+        self.assertEqual((commit_sha, branch_name, commit_ts), ("unknown", "unknown", "unknown"))
+        self.assertIn("detected dubious ownership", warning)
 
-    def test_missing_git_degrades_to_unknown(self):
+    def test_missing_git_degrades_to_unknown_with_a_reason(self):
         with mock.patch.object(generate_report.subprocess, "run", side_effect=FileNotFoundError("git")):
-            metadata = generate_report._git_source_metadata("/cuvslam")
+            commit_sha, branch_name, commit_ts, warning = generate_report._git_source_metadata("/cuvslam")
 
-        self.assertEqual(metadata, ("unknown", "unknown", "unknown"))
+        self.assertEqual((commit_sha, branch_name, commit_ts), ("unknown", "unknown", "unknown"))
+        self.assertIn("git is not installed", warning)
 
     def test_git_failure_is_not_written_to_the_process_log(self):
         """A directory outside any repository must not leak git's fatal error to stderr."""
         script = (
             "from cuvslam_tools.reporter.generate_report import _git_source_metadata\n"
-            "print(_git_source_metadata(__import__('sys').argv[1]))\n"
+            "print(_git_source_metadata(__import__('sys').argv[1])[:3])\n"
         )
         env = dict(os.environ)
         package_root = Path(generate_report.__file__).resolve().parents[2]
@@ -82,6 +84,55 @@ class TestGitSourceMetadata(unittest.TestCase):
 
         self.assertNotIn("fatal:", completed.stderr)
         self.assertIn("('unknown', 'unknown', 'unknown')", completed.stdout)
+
+
+class TestReportProvenanceHeader(unittest.TestCase):
+    """The report header must explain unknown provenance without the run log."""
+
+    UNRESOLVED = ("unknown", "unknown", "unknown", "Provenance unavailable for /cuvslam: git is not installed")
+    RESOLVED = ("1234567890abcdef", "feature/branch", "2026-08-31/17:08:04/+0000", "")
+
+    def _render_html(self, metadata):
+        with tempfile.TemporaryDirectory() as output_dir:
+            with mock.patch.object(generate_report, "_git_source_metadata", return_value=metadata):
+                generate_report.generate_report(output_dir, [], [])
+            return (Path(output_dir) / "report.html").read_text(encoding="utf-8")
+
+    def _render_pdf_html(self, metadata):
+        captured = {}
+
+        class CapturingHtml:
+            def __init__(self, **kwargs):
+                captured["html"] = kwargs["string"]
+
+            def write_pdf(self, path):
+                Path(path).write_bytes(b"")
+
+        weasyprint = types.ModuleType("weasyprint")
+        weasyprint.HTML = CapturingHtml
+        with tempfile.TemporaryDirectory() as output_dir:
+            with mock.patch.dict(sys.modules, {"weasyprint": weasyprint}):
+                with mock.patch.object(generate_report, "_git_source_metadata", return_value=metadata):
+                    generate_report.generate_report(output_dir, [], [], generate_pdf=True)
+        return captured["html"]
+
+    def test_warning_is_rendered_in_the_html_report(self):
+        html = self._render_html(self.UNRESOLVED)
+
+        self.assertIn("git is not installed", html)
+
+    def test_warning_is_rendered_in_the_pdf_report(self):
+        pdf_html = self._render_pdf_html(self.UNRESOLVED)
+
+        self.assertIn("git is not installed", pdf_html)
+
+    def test_resolved_provenance_is_reported_without_a_warning_row(self):
+        for name, rendered in (("html", self._render_html(self.RESOLVED)),
+                               ("pdf", self._render_pdf_html(self.RESOLVED))):
+            with self.subTest(report=name):
+                self.assertIn("1234567890abcdef", rendered)
+                self.assertIn("feature/branch", rendered)
+                self.assertNotIn("Provenance", rendered)
 
 
 class TestPdfGeneration(unittest.TestCase):

--- a/tools/python_tools/cuvslam_tools/tests/test_reporter_cli.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_reporter_cli.py
@@ -12,6 +12,8 @@
 # By using, reproducing, modifying, distributing, performing, or displaying any portion or element
 # of the software or derivative works thereof, you agree to be bound by this License.
 
+import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -33,6 +35,53 @@ class TestReporterCli(unittest.TestCase):
             resolved = cli._resolve_config_path("kitti/kitti-vio_slam_gt.cfg", datasets_root)
 
         self.assertEqual(resolved, config_path)
+
+
+class TestGitSourceMetadata(unittest.TestCase):
+    def test_metadata_is_read_from_git(self):
+        outputs = ["1234567890abcdef", "feature/branch", "2026-08-31 17:08:04 +0000"]
+        with mock.patch.object(generate_report.subprocess, "run") as run:
+            run.side_effect = [mock.Mock(stdout=f"{value}\n") for value in outputs]
+            metadata = generate_report._git_source_metadata("/cuvslam")
+
+        self.assertEqual(metadata, ("1234567890abcdef", "feature/branch", "2026-08-31/17:08:04/+0000"))
+
+    def test_unreadable_repository_degrades_to_unknown(self):
+        error = subprocess.CalledProcessError(128, ["git", "rev-parse", "HEAD"])
+        error.stderr = "fatal: detected dubious ownership in repository at '/cuvslam'\n"
+        with mock.patch.object(generate_report.subprocess, "run", side_effect=error):
+            metadata = generate_report._git_source_metadata("/cuvslam")
+
+        self.assertEqual(metadata, ("unknown", "unknown", "unknown"))
+
+    def test_missing_git_degrades_to_unknown(self):
+        with mock.patch.object(generate_report.subprocess, "run", side_effect=FileNotFoundError("git")):
+            metadata = generate_report._git_source_metadata("/cuvslam")
+
+        self.assertEqual(metadata, ("unknown", "unknown", "unknown"))
+
+    def test_git_failure_is_not_written_to_the_process_log(self):
+        """A directory outside any repository must not leak git's fatal error to stderr."""
+        script = (
+            "from cuvslam_tools.reporter.generate_report import _git_source_metadata\n"
+            "print(_git_source_metadata(__import__('sys').argv[1]))\n"
+        )
+        env = dict(os.environ)
+        package_root = Path(generate_report.__file__).resolve().parents[2]
+        env["PYTHONPATH"] = os.pathsep.join([str(package_root), env.get("PYTHONPATH", "")])
+
+        with tempfile.TemporaryDirectory() as non_repo_dir:
+            env["MPLCONFIGDIR"] = non_repo_dir
+            completed = subprocess.run(
+                [sys.executable, "-c", script, non_repo_dir],
+                capture_output=True,
+                universal_newlines=True,
+                env=env,
+                check=True,
+            )
+
+        self.assertNotIn("fatal:", completed.stderr)
+        self.assertIn("('unknown', 'unknown', 'unknown')", completed.stdout)
 
 
 class TestPdfGeneration(unittest.TestCase):


### PR DESCRIPTION
The eval container mounts the source tree from the host and runs as root, so Git refuses the repo as dubiously owned and every provenance query fails. The reporter caught the failure and wrote "unknown" for branch, commit, and commit date, so eval reports carried no provenance while Git's three fatals went to the run log on their inherited stderr, once per dataset.

Allow-list the mount in run_eval.sh so the fields resolve, and capture Git's output in the reporter so any future failure degrades the header with one actionable warning instead of raw fatals in an unrelated part of the log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report generation when Git provenance is unavailable or the project directory is not recognized as trusted.
  * Git-related errors are now handled gracefully, allowing evaluation to continue with clear warnings and an “unknown” provenance status.
  * Suppressed confusing Git error output from generated reports.

* **New Features**
  * HTML and PDF reports now display provenance warnings when metadata cannot be resolved.

* **Tests**
  * Added coverage for successful metadata collection and fallback behavior when Git or repository information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->