### PR TITLE
[fix] Make the tracker's ground-truth source explicit

### DIFF
--- a/tools/python_tools/README.md
+++ b/tools/python_tools/README.md
@@ -353,6 +353,16 @@ cuvslam_reporter \
 
 The reporter requires `--test_config` to point to one config file. Relative paths are resolved from the current working directory; `--datasets_root` is only used to locate dataset folders referenced by that config.
 
+### Ground truth
+
+Every sequence in a reporter config names its reference explicitly, and a sequence that names one it cannot read fails the run:
+
+- `"gt_file_path": "gt.txt"` — KITTI-format poses, absolute or relative to the sequence folder. A missing file is an error.
+- `"gt_from_shuttle": true` — the backward pass of a shuttle replay is scored against the forward pass. This measures repeatability, not accuracy: an error that repeats in both directions cancels out. Requires `"repeat_type": "Shuttle"` with `"sequence_num_repeats"` of at least 1, and cannot be combined with `gt_file_path`.
+- Neither — the sequence runs without accuracy metrics and its ATE/ARE columns stay blank.
+
+`cuvslam_tracker` takes the same two choices as `--gt_path` and `--gt_from_shuttle`.
+
 ## Validation
 
 Run a multi-dataset validation config:

--- a/tools/python_tools/cuvslam_tools/reporter/execution.py
+++ b/tools/python_tools/cuvslam_tools/reporter/execution.py
@@ -124,13 +124,17 @@ def _load_track():
     return track
 
 
-def _validate_sequence_flags(index: int, sequence: dict, keys: tuple[str, ...]) -> None:
+# Checked only where present, so a disabled stub missing the required keys still passes.
+_SEQUENCE_FLAGS = ("enable", "use_slam", "gt_from_shuttle")
+
+
+def _validate_sequence_flags(index: int, sequence: dict) -> None:
     """Reject sequence flags that are not real booleans.
 
     bool("false") is True, so a quoted flag would switch on the very thing it
     says to switch off.
     """
-    for key in keys:
+    for key in _SEQUENCE_FLAGS:
         if key in sequence and not isinstance(sequence[key], bool):
             raise ValueError(f"Reporter config sequence_cfgs[{index}] key {key} must be a boolean")
 
@@ -155,7 +159,7 @@ def _validate_reporter_config(reporter_config: dict) -> tuple[str, list[dict]]:
     for index, sequence in enumerate(sequence_cfgs):
         if not isinstance(sequence, dict):
             raise ValueError(f"Reporter config sequence_cfgs[{index}] must be an object")
-        _validate_sequence_flags(index, sequence, ("enable",))
+        _validate_sequence_flags(index, sequence)
         if sequence.get("enable") is False:
             continue
         for key in ("sequence_title", "sequence_folder"):
@@ -165,7 +169,6 @@ def _validate_reporter_config(reporter_config: dict) -> tuple[str, list[dict]]:
                 )
             if not isinstance(sequence[key], str):
                 raise ValueError(f"Reporter config sequence_cfgs[{index}] key {key} must be a string")
-        _validate_sequence_flags(index, sequence, ("use_slam", "gt_from_shuttle"))
 
     return dataset_folder, sequence_cfgs
 

--- a/tools/python_tools/cuvslam_tools/reporter/execution.py
+++ b/tools/python_tools/cuvslam_tools/reporter/execution.py
@@ -168,6 +168,7 @@ def process_sequence(sequence: dict, args: argparse.Namespace, datasets_root: st
     args_copy.dataset = os.path.join(dataset_base, sequence["sequence_folder"])
     args_copy.config_path = os.path.join(args_copy.dataset, sequence.get("edex_file", "stereo.edex"))
     args_copy.gt_path = _resolve_sequence_gt_path(sequence)
+    args_copy.gt_from_shuttle = bool(sequence.get("gt_from_shuttle", False))
     args_copy.camera_ids = sequence.get("cameras")
     args_copy.use_slam = bool(sequence.get("use_slam", False))
     if "repeat_type" in sequence:

--- a/tools/python_tools/cuvslam_tools/reporter/execution.py
+++ b/tools/python_tools/cuvslam_tools/reporter/execution.py
@@ -124,6 +124,17 @@ def _load_track():
     return track
 
 
+def _validate_sequence_flags(index: int, sequence: dict, keys: tuple[str, ...]) -> None:
+    """Reject sequence flags that are not real booleans.
+
+    bool("false") is True, so a quoted flag would switch on the very thing it
+    says to switch off.
+    """
+    for key in keys:
+        if key in sequence and not isinstance(sequence[key], bool):
+            raise ValueError(f"Reporter config sequence_cfgs[{index}] key {key} must be a boolean")
+
+
 def _validate_reporter_config(reporter_config: dict) -> tuple[str, list[dict]]:
     """Validate reporter config shape and return dataset and sequence entries."""
     if not isinstance(reporter_config, dict):
@@ -144,6 +155,7 @@ def _validate_reporter_config(reporter_config: dict) -> tuple[str, list[dict]]:
     for index, sequence in enumerate(sequence_cfgs):
         if not isinstance(sequence, dict):
             raise ValueError(f"Reporter config sequence_cfgs[{index}] must be an object")
+        _validate_sequence_flags(index, sequence, ("enable",))
         if sequence.get("enable") is False:
             continue
         for key in ("sequence_title", "sequence_folder"):
@@ -153,6 +165,7 @@ def _validate_reporter_config(reporter_config: dict) -> tuple[str, list[dict]]:
                 )
             if not isinstance(sequence[key], str):
                 raise ValueError(f"Reporter config sequence_cfgs[{index}] key {key} must be a string")
+        _validate_sequence_flags(index, sequence, ("use_slam", "gt_from_shuttle"))
 
     return dataset_folder, sequence_cfgs
 
@@ -168,9 +181,9 @@ def process_sequence(sequence: dict, args: argparse.Namespace, datasets_root: st
     args_copy.dataset = os.path.join(dataset_base, sequence["sequence_folder"])
     args_copy.config_path = os.path.join(args_copy.dataset, sequence.get("edex_file", "stereo.edex"))
     args_copy.gt_path = _resolve_sequence_gt_path(sequence)
-    args_copy.gt_from_shuttle = bool(sequence.get("gt_from_shuttle", False))
+    args_copy.gt_from_shuttle = sequence.get("gt_from_shuttle", False)
     args_copy.camera_ids = sequence.get("cameras")
-    args_copy.use_slam = bool(sequence.get("use_slam", False))
+    args_copy.use_slam = sequence.get("use_slam", False)
     if "repeat_type" in sequence:
         args_copy.repeat_type = (sequence["repeat_type"] or "none").lower()
     if "sequence_num_repeats" in sequence:

--- a/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from cuvslam_tools.tracker.ground_truth import load_gt_transforms, resolve_gt_file
+
+IDENTITY_POSE = "1 0 0 0 0 1 0 0 0 0 1 0"
+
+
+class TestResolveGtFile(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dataset = Path(self._tmp.name)
+
+    def test_relative_path_resolves_against_the_dataset_directory(self):
+        (self.dataset / "gt_rect.txt").write_text(IDENTITY_POSE, encoding="utf-8")
+
+        resolved = resolve_gt_file(str(self.dataset), "gt_rect.txt", False, "none", 0)
+
+        self.assertEqual(resolved, os.path.join(str(self.dataset), "gt_rect.txt"))
+
+    def test_absolute_path_is_used_as_is(self):
+        gt_file = self.dataset / "poses.txt"
+        gt_file.write_text(IDENTITY_POSE, encoding="utf-8")
+
+        resolved = resolve_gt_file("/somewhere/else", str(gt_file), False, "none", 0)
+
+        self.assertEqual(resolved, str(gt_file))
+
+    def test_missing_ground_truth_file_stops_the_run(self):
+        with self.assertRaises(FileNotFoundError) as cm:
+            resolve_gt_file(str(self.dataset), "gt_rect.txt", False, "shuttle", 1)
+
+        self.assertIn("gt_rect.txt", str(cm.exception))
+
+    def test_no_requested_ground_truth_reads_no_file(self):
+        # A gt.txt sitting in the dataset directory must not be picked up implicitly.
+        (self.dataset / "gt.txt").write_text(IDENTITY_POSE, encoding="utf-8")
+
+        self.assertIsNone(resolve_gt_file(str(self.dataset), None, False, "none", 0))
+        self.assertIsNone(resolve_gt_file(str(self.dataset), "", False, "shuttle", 1))
+
+    def test_shuttle_ground_truth_reads_no_file(self):
+        self.assertIsNone(resolve_gt_file(str(self.dataset), None, True, "shuttle", 1))
+
+    def test_shuttle_ground_truth_rejects_a_pose_file(self):
+        (self.dataset / "gt.txt").write_text(IDENTITY_POSE, encoding="utf-8")
+
+        with self.assertRaisesRegex(ValueError, "Conflicting ground truth"):
+            resolve_gt_file(str(self.dataset), "gt.txt", True, "shuttle", 1)
+
+    def test_shuttle_ground_truth_requires_a_shuttle_replay(self):
+        with self.assertRaisesRegex(ValueError, "repeat_type='shuttle'"):
+            resolve_gt_file(str(self.dataset), None, True, "repeat", 1)
+
+        with self.assertRaisesRegex(ValueError, "num_loops > 0"):
+            resolve_gt_file(str(self.dataset), None, True, "shuttle", 0)
+
+
+class TestLoadGtTransforms(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dataset = Path(self._tmp.name)
+
+    def test_each_line_becomes_a_homogeneous_transform(self):
+        gt_file = self.dataset / "gt.txt"
+        gt_file.write_text(f"{IDENTITY_POSE}\n1 0 0 2 0 1 0 3 0 0 1 4\n", encoding="utf-8")
+
+        transforms = load_gt_transforms(str(gt_file))
+
+        self.assertEqual(len(transforms), 2)
+        np.testing.assert_allclose(transforms[0], np.eye(4))
+        np.testing.assert_allclose(transforms[1][:3, 3], [2.0, 3.0, 4.0])
+        np.testing.assert_allclose(transforms[1][3], [0.0, 0.0, 0.0, 1.0])
+
+    def test_a_line_without_twelve_values_names_the_line(self):
+        gt_file = self.dataset / "gt.txt"
+        gt_file.write_text(f"{IDENTITY_POSE}\n1 0 0 2\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(ValueError, r"gt\.txt:2"):
+            load_gt_transforms(str(gt_file))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
@@ -43,7 +43,9 @@ class TestResolveGtFile(unittest.TestCase):
         video.write_bytes(b"")
         (self.dataset / "gt_rect.txt").write_text(IDENTITY_POSE, encoding="utf-8")
 
-        resolved = resolve_gt_file(str(video), "gt_rect.txt", False, "none", 0)
+        resolved = resolve_gt_file(
+            str(video), "gt_rect.txt", gt_from_shuttle=False, repeat_type="none", num_loops=0
+        )
 
         self.assertEqual(resolved, os.path.join(str(self.dataset), "gt_rect.txt"))
 

--- a/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
@@ -102,6 +102,16 @@ class TestLoadGtTransforms(unittest.TestCase):
         np.testing.assert_allclose(transforms[1][:3, 3], [2.0, 3.0, 4.0])
         np.testing.assert_allclose(transforms[1][3], [0.0, 0.0, 0.0, 1.0])
 
+    def test_a_line_with_a_non_finite_value_names_the_line(self):
+        # float() parses these, so they need a guard of their own.
+        for literal in ("nan", "inf"):
+            with self.subTest(literal=literal):
+                gt_file = self.dataset / "gt.txt"
+                gt_file.write_text(f"{IDENTITY_POSE}\n1 0 0 {literal} 0 1 0 0 0 0 1 0\n", encoding="utf-8")
+
+                with self.assertRaisesRegex(ValueError, r"gt\.txt:2 holds a non-finite value"):
+                    load_gt_transforms(str(gt_file))
+
     def test_a_line_without_twelve_values_names_the_line(self):
         gt_file = self.dataset / "gt.txt"
         gt_file.write_text(f"{IDENTITY_POSE}\n1 0 0 2\n", encoding="utf-8")

--- a/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
@@ -111,7 +111,9 @@ class TestLoadGtTransforms(unittest.TestCase):
                 gt_file = self.dataset / "gt.txt"
                 gt_file.write_text(f"{IDENTITY_POSE}\n1 0 0 {literal} 0 1 0 0 0 0 1 0\n", encoding="utf-8")
 
-                with self.assertRaisesRegex(ValueError, r"gt\.txt:2 holds a non-finite value"):
+                with self.assertRaisesRegex(
+                    ValueError, rf"gt\.txt:2 holds a non-finite value \({literal}\)"
+                ):
                     load_gt_transforms(str(gt_file))
 
     def test_a_line_without_twelve_values_names_the_line(self):

--- a/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_ground_truth.py
@@ -37,6 +37,16 @@ class TestResolveGtFile(unittest.TestCase):
 
         self.assertEqual(resolved, os.path.join(str(self.dataset), "gt_rect.txt"))
 
+    def test_relative_path_resolves_beside_a_video_dataset(self):
+        # A video input names the file, not a directory, so its poses sit next to it.
+        video = self.dataset / "run.mp4"
+        video.write_bytes(b"")
+        (self.dataset / "gt_rect.txt").write_text(IDENTITY_POSE, encoding="utf-8")
+
+        resolved = resolve_gt_file(str(video), "gt_rect.txt", False, "none", 0)
+
+        self.assertEqual(resolved, os.path.join(str(self.dataset), "gt_rect.txt"))
+
     def test_absolute_path_is_used_as_is(self):
         gt_file = self.dataset / "poses.txt"
         gt_file.write_text(IDENTITY_POSE, encoding="utf-8")

--- a/tools/python_tools/cuvslam_tools/tests/test_reporter_execution.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_reporter_execution.py
@@ -85,10 +85,41 @@ class TestReporterExecution(unittest.TestCase):
         self.assertEqual(args_copy.dataset, expected_dataset)
         self.assertEqual(args_copy.config_path, os.path.join(expected_dataset, "custom.edex"))
         self.assertEqual(args_copy.gt_path, "poses/gt.txt")
+        self.assertFalse(args_copy.gt_from_shuttle)
         self.assertEqual(args_copy.camera_ids, [1, 0])
         self.assertTrue(args_copy.use_slam)
         self.assertEqual(args_copy.repeat_type, "repeat")
         self.assertEqual(args_copy.num_loops, 3)
+
+    def test_process_sequence_forwards_shuttle_ground_truth_opt_in(self):
+        captured_args = []
+        stat = object()
+
+        class _Result:
+            pass
+
+        def track(args):
+            captured_args.append(args)
+            result = _Result()
+            result.stat = stat
+            return result
+
+        args = argparse.Namespace(config_path="", repeat_type="none", num_loops=0)
+        sequence = {
+            "enable": True,
+            "sequence_title": "seq-a",
+            "sequence_folder": "seq-a-folder",
+            "gt_from_shuttle": True,
+            "repeat_type": "Shuttle",
+            "sequence_num_repeats": 1,
+        }
+
+        with mock.patch.object(execution, "_load_track", return_value=track):
+            execution.process_sequence(sequence, args, "/datasets", "dataset")
+
+        args_copy = captured_args[0]
+        self.assertTrue(args_copy.gt_from_shuttle)
+        self.assertIsNone(args_copy.gt_path)
 
     def test_process_sequence_defaults_edex_and_warns_on_empty_gt_path(self):
         captured_args = []

--- a/tools/python_tools/cuvslam_tools/tests/test_reporter_execution.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_reporter_execution.py
@@ -262,6 +262,10 @@ class TestReporterExecution(unittest.TestCase):
                 {"dataset_folder": "dataset", "sequence_cfgs": [{"enable": "false"}]},
                 r"Reporter config sequence_cfgs\[0\] key enable must be a boolean",
             ),
+            (
+                {"dataset_folder": "dataset", "sequence_cfgs": [{"enable": False, "gt_from_shuttle": "false"}]},
+                r"Reporter config sequence_cfgs\[0\] key gt_from_shuttle must be a boolean",
+            ),
         ]
 
         for reporter_config, error in cases:
@@ -273,6 +277,17 @@ class TestReporterExecution(unittest.TestCase):
                         "/datasets",
                         max_workers=1,
                     )
+
+    def test_run_parallel_tracking_skips_a_disabled_sequence_stub(self):
+        # A disabled sequence may still be a stub: only flags it does carry are checked.
+        stats = execution.run_parallel_tracking(
+            {"dataset_folder": "dataset", "sequence_cfgs": [{"enable": False, "use_slam": True}]},
+            argparse.Namespace(),
+            "/datasets",
+            max_workers=1,
+        )
+
+        self.assertEqual(stats, [])
 
     def test_run_parallel_tracking_raises_when_all_enabled_sequences_fail(self):
         reporter_config = {

--- a/tools/python_tools/cuvslam_tools/tests/test_reporter_execution.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_reporter_execution.py
@@ -242,6 +242,26 @@ class TestReporterExecution(unittest.TestCase):
                 {"dataset_folder": "dataset", "sequence_cfgs": [{"sequence_title": "seq-a", "sequence_folder": 1}]},
                 r"Reporter config sequence_cfgs\[0\] key sequence_folder must be a string",
             ),
+            (
+                {
+                    "dataset_folder": "dataset",
+                    "sequence_cfgs": [
+                        {"sequence_title": "seq-a", "sequence_folder": "seq-a", "gt_from_shuttle": "false"}
+                    ],
+                },
+                r"Reporter config sequence_cfgs\[0\] key gt_from_shuttle must be a boolean",
+            ),
+            (
+                {
+                    "dataset_folder": "dataset",
+                    "sequence_cfgs": [{"sequence_title": "seq-a", "sequence_folder": "seq-a", "use_slam": 1}],
+                },
+                r"Reporter config sequence_cfgs\[0\] key use_slam must be a boolean",
+            ),
+            (
+                {"dataset_folder": "dataset", "sequence_cfgs": [{"enable": "false"}]},
+                r"Reporter config sequence_cfgs\[0\] key enable must be a boolean",
+            ),
         ]
 
         for reporter_config, error in cases:

--- a/tools/python_tools/cuvslam_tools/tracker/cli.py
+++ b/tools/python_tools/cuvslam_tools/tracker/cli.py
@@ -100,6 +100,24 @@ def add_tracker_arguments(parser: argparse.ArgumentParser) -> None:
         default="none",
         help="Replay mode.",
     )
+    parser.add_argument(
+        "--gt_path",
+        type=str,
+        default="",
+        help=(
+            "KITTI-format ground-truth poses, absolute or relative to --dataset. "
+            "Tracking stops with an error when the file is missing."
+        ),
+    )
+    parser.add_argument(
+        "--gt_from_shuttle",
+        type=_str2bool,
+        default=False,
+        help=(
+            "Score the backward shuttle pass against the forward one instead of a ground-truth file. "
+            "Requires --repeat_type shuttle with --num_loops > 0, and rules out --gt_path."
+        ),
+    )
     parser.add_argument("--blackout_period", type=int, default=0, help="Blackout series period in frames.")
     parser.add_argument("--blackout_duration", type=int, default=10, help="Consecutive blacked-out frames per series.")
     parser.add_argument("--config_path", type=str, default="", help="Path to the stereo.edex file.")
@@ -271,7 +289,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         _normalize_tracker_binding_args(args)
         tracker_results = track(args)
-    except ValueError as exc:
+    except (FileNotFoundError, ValueError) as exc:
         parser.error(str(exc))
     if args.output_dir:
         save_tracker_stats(tracker_results.stat, args.output_dir)

--- a/tools/python_tools/cuvslam_tools/tracker/cli.py
+++ b/tools/python_tools/cuvslam_tools/tracker/cli.py
@@ -103,7 +103,7 @@ def add_tracker_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--gt_path",
         type=str,
-        default="",
+        default="gt.txt",
         help=(
             "KITTI-format ground-truth poses, absolute or relative to --dataset. "
             "Tracking stops with an error when the file is missing."

--- a/tools/python_tools/cuvslam_tools/tracker/dataset_reader.py
+++ b/tools/python_tools/cuvslam_tools/tracker/dataset_reader.py
@@ -20,6 +20,7 @@ import numpy as np
 
 import cuvslam as vslam
 from cuvslam_tools.tracker import conversions as conv
+from cuvslam_tools.tracker.ground_truth import load_gt_transforms, resolve_gt_file
 
 
 class Processing(Protocol):
@@ -58,8 +59,8 @@ class DatasetReader:
 
     def __init__(self, dataset_path: str, stereo_edex: Optional[str] = None,
                  num_loops: int = 0, repeat_type: str = "none",
-                 gt_path: Optional[str] = None):
-        """Initialize replay state and optional ground-truth pose loading."""
+                 gt_path: Optional[str] = None, gt_from_shuttle: bool = False):
+        """Initialize replay state and the requested ground-truth source."""
         repeat_type = (repeat_type or "none").lower()
         if repeat_type not in ("none", "repeat", "shuttle"):
             raise ValueError(f"Invalid repeat_type {repeat_type!r}; expected none|repeat|shuttle")
@@ -76,25 +77,14 @@ class DatasetReader:
         self.frame_id_start = 0
         self.current_loop = 0
         self.replay_forward = True
-        self.gt_from_shuttle = False
+        # Set explicitly by the caller: the first forward pass becomes the reference the backward
+        # pass is scored against, and replay() fills gt_transforms as it goes.
+        self.gt_from_shuttle = gt_from_shuttle
         self.gt_transforms = []
 
-        if gt_path is None:
-            self.gt_path = os.path.join(dataset_path, 'gt.txt')
-        elif os.path.isabs(gt_path):
-            self.gt_path = gt_path
-        else:
-            self.gt_path = os.path.join(dataset_path, gt_path)
-        if os.path.exists(self.gt_path):
-            with open(self.gt_path, 'r') as f:
-                for line in f:
-                    transform_12 = [float(value) for value in line.split()]
-                    assert len(transform_12) == 12, "Each line should have 12 float values"
-                    transform = np.vstack((np.array(transform_12).reshape(3, 4), np.array([0, 0, 0, 1])))
-                    self.gt_transforms.append(transform)
-        elif self.repeat_type == "shuttle" and self.num_loops > 0:
-            # consider first forward run in shuttle mode as ground truth
-            self.gt_from_shuttle = True
+        self.gt_path = resolve_gt_file(dataset_path, gt_path, gt_from_shuttle, repeat_type, num_loops)
+        if self.gt_path is not None:
+            self.gt_transforms = load_gt_transforms(self.gt_path)
 
     @staticmethod
     def get_camera(intrinsics: Dict, transform: List[List[float]]) -> vslam.Camera:

--- a/tools/python_tools/cuvslam_tools/tracker/edex_reader.py
+++ b/tools/python_tools/cuvslam_tools/tracker/edex_reader.py
@@ -35,9 +35,10 @@ class EdexReader(DatasetReader):
     def __init__(self, edex_dir: str, stereo_edex: Optional[str] = None, num_loops: int = 0,
                  rgbd_mode: bool = False, repeat_type: str = "none",
                  cache_uncompressed: bool = False, gt_path: Optional[str] = None,
-                 camera_ids: Optional[List[int]] = None):
+                 camera_ids: Optional[List[int]] = None, gt_from_shuttle: bool = False):
         """Load EDEX configuration, rig calibration, frame metadata, and optional IMU data."""
-        super().__init__(edex_dir, stereo_edex, num_loops, repeat_type, gt_path=gt_path)
+        super().__init__(edex_dir, stereo_edex, num_loops, repeat_type, gt_path=gt_path,
+                         gt_from_shuttle=gt_from_shuttle)
         self.rgbd_mode = rgbd_mode
         self.cache_uncompressed = cache_uncompressed
         self.rgbd_settings = None

--- a/tools/python_tools/cuvslam_tools/tracker/ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tracker/ground_truth.py
@@ -53,7 +53,9 @@ def resolve_gt_file(dataset_path: str,
     if not gt_path:
         return None
 
-    resolved = gt_path if os.path.isabs(gt_path) else os.path.join(dataset_path, gt_path)
+    # A video input names the file itself, so its poses sit beside it, the way stereo.edex does.
+    base = os.path.dirname(dataset_path) if os.path.isfile(dataset_path) else dataset_path
+    resolved = gt_path if os.path.isabs(gt_path) else os.path.join(base, gt_path)
     if not os.path.isfile(resolved):
         raise FileNotFoundError(
             f"Ground-truth file not found: {resolved}. Provide the file, drop the ground-truth path to "

--- a/tools/python_tools/cuvslam_tools/tracker/ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tracker/ground_truth.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+"""Selection and loading of the ground truth a tracker run is scored against.
+
+A run has exactly one reference: a KITTI-format pose file, the forward pass of a shuttle replay, or
+nothing at all. Which one it is comes from the config, never from what happens to be on disk.
+"""
+
+import os
+from typing import List, Optional
+
+import numpy as np
+
+
+def resolve_gt_file(dataset_path: str,
+                    gt_path: Optional[str],
+                    gt_from_shuttle: bool,
+                    repeat_type: str,
+                    num_loops: int) -> Optional[str]:
+    """Validate the requested ground-truth source and return the pose file to read, if any.
+
+    Returns None when the run has no pose file to read, which covers both the shuttle reference and
+    a run with no ground truth. Raises when the request cannot be honoured, so a missing or
+    contradictory ground truth stops the run instead of quietly producing metrics against something
+    the caller did not ask for.
+    """
+    if gt_from_shuttle:
+        if gt_path:
+            raise ValueError(
+                f"Conflicting ground truth: gt_from_shuttle is set alongside the pose file {gt_path!r}. "
+                "Pick one source."
+            )
+        if repeat_type != "shuttle" or num_loops <= 0:
+            raise ValueError(
+                "gt_from_shuttle scores the backward shuttle pass against the forward one, so it needs "
+                f"repeat_type='shuttle' with num_loops > 0; got repeat_type={repeat_type!r}, "
+                f"num_loops={num_loops}."
+            )
+        return None
+
+    if not gt_path:
+        return None
+
+    resolved = gt_path if os.path.isabs(gt_path) else os.path.join(dataset_path, gt_path)
+    if not os.path.isfile(resolved):
+        raise FileNotFoundError(
+            f"Ground-truth file not found: {resolved}. Provide the file, drop the ground-truth path to "
+            "run without accuracy metrics, or set gt_from_shuttle to score a shuttle run against its "
+            "own forward pass."
+        )
+    return resolved
+
+
+def load_gt_transforms(gt_file: str) -> List[np.ndarray]:
+    """Read a KITTI-format pose file into a list of 4x4 transforms."""
+    bottom_row = np.array([0.0, 0.0, 0.0, 1.0])
+    transforms = []
+    with open(gt_file, 'r') as f:
+        for line_number, line in enumerate(f, start=1):
+            values = [float(value) for value in line.split()]
+            if len(values) != 12:
+                raise ValueError(
+                    f"{gt_file}:{line_number} holds {len(values)} values; KITTI poses need 12 per line."
+                )
+            transforms.append(np.vstack((np.array(values).reshape(3, 4), bottom_row)))
+    return transforms

--- a/tools/python_tools/cuvslam_tools/tracker/ground_truth.py
+++ b/tools/python_tools/cuvslam_tools/tracker/ground_truth.py
@@ -18,6 +18,7 @@ A run has exactly one reference: a KITTI-format pose file, the forward pass of a
 nothing at all. Which one it is comes from the config, never from what happens to be on disk.
 """
 
+import math
 import os
 from typing import List, Optional
 
@@ -76,5 +77,10 @@ def load_gt_transforms(gt_file: str) -> List[np.ndarray]:
                 raise ValueError(
                     f"{gt_file}:{line_number} holds {len(values)} values; KITTI poses need 12 per line."
                 )
+            # float() takes "nan" and "inf", and either one only surfaces later as an SVD that
+            # will not converge inside the metrics.
+            for value in values:
+                if not math.isfinite(value):
+                    raise ValueError(f"{gt_file}:{line_number} holds a non-finite value ({value}).")
             transforms.append(np.vstack((np.array(values).reshape(3, 4), bottom_row)))
     return transforms

--- a/tools/python_tools/cuvslam_tools/tracker/runner.py
+++ b/tools/python_tools/cuvslam_tools/tracker/runner.py
@@ -477,7 +477,8 @@ def track(args: argparse.Namespace,
     if args.dataset.endswith('.mp4'):
         dataset = VideoReader(args.dataset, stereo_edex=args.config_path,
                               num_loops=args.num_loops, repeat_type=args.repeat_type,
-                              gt_path=getattr(args, 'gt_path', None))
+                              gt_path=getattr(args, 'gt_path', None),
+                              gt_from_shuttle=getattr(args, 'gt_from_shuttle', False))
     else:
         rgbd_mode = args.odometry_mode == vslam.Odometry.OdometryMode.RGBD
         dataset = EdexReader(args.dataset, stereo_edex=args.config_path,
@@ -485,7 +486,8 @@ def track(args: argparse.Namespace,
                              repeat_type=args.repeat_type,
                              cache_uncompressed=getattr(args, 'cache_uncompressed', False),
                              gt_path=getattr(args, 'gt_path', None),
-                             camera_ids=getattr(args, 'camera_ids', None))
+                             camera_ids=getattr(args, 'camera_ids', None),
+                             gt_from_shuttle=getattr(args, 'gt_from_shuttle', False))
 
     tracker_results = TrackerResults()
     if args.sequence_title:

--- a/tools/python_tools/cuvslam_tools/tracker/video_reader.py
+++ b/tools/python_tools/cuvslam_tools/tracker/video_reader.py
@@ -28,9 +28,11 @@ class VideoReader(DatasetReader):
     """Replay video frames with calibration loaded from a stereo.edex file."""
 
     def __init__(self, video_path: str, stereo_edex: Optional[str] = None, num_loops: int = 0,
-                 repeat_type: str = "none", gt_path: Optional[str] = None):
+                 repeat_type: str = "none", gt_path: Optional[str] = None,
+                 gt_from_shuttle: bool = False):
         """Load calibration and preload all video frames into memory."""
-        super().__init__(video_path, stereo_edex, num_loops, repeat_type, gt_path=gt_path)
+        super().__init__(video_path, stereo_edex, num_loops, repeat_type, gt_path=gt_path,
+                         gt_from_shuttle=gt_from_shuttle)
         self.replay_forward = True
         self.buffer = []  # Store frames in memory
 


### PR DESCRIPTION
A reporter sequence that named a ground-truth file which did not exist did not fail. When the sequence also used shuttle replay, the reader quietly substituted the tracker's own first forward pass as the reference, and the report then showed ATE/ARE columns that measured forward/backward repeatability rather than accuracy, with nothing to distinguish the two.

Ground truth is now chosen only by config, never by what happens to be on disk. resolve_gt_file() is the single decision point: a named file that is missing raises FileNotFoundError and stops the run, the shuttle reference has to be requested with the new gt_from_shuttle flag, and asking for both at once or asking for the shuttle reference without a shuttle replay is an error. The implicit <dataset>/gt.txt probe is gone for the same reason; it also contradicted the intent already recorded in test_tum_conversion, that omitting gt_file_path runs a sequence with no ground truth.

cuvslam_tracker gains --gt_path, which it previously lacked even though the runner read the argument, and --gt_from_shuttle. The rules live in a module free of the cuvslam binding so they stay covered by the tools test suite, which runs before the binding is built.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting ground-truth data from KITTI-format pose files or shuttle replay passes.
  - Added command-line options for specifying ground-truth files and enabling shuttle-based scoring.
  - Relative ground-truth paths are resolved from the dataset location.
  - KITTI pose files are validated and loaded for tracking comparisons.

- **Bug Fixes**
  - Added validation for conflicting, missing, or malformed ground-truth inputs and non-boolean reporter settings.

- **Documentation**
  - Documented ground-truth source options, configuration settings, and usage constraints.

- **Tests**
  - Added coverage for file resolution, pose parsing, validation, and shuttle ground-truth forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->