### PR TITLE
[clean] remove the unused SOF_USE_SMALLER_NCC build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ option(USE_LMDB "Use lmdb library for the database of landmarks (map)" ON)
 option(USE_CUDA "Use CUDA Toolkit" ON)
 option(ENFORCE_GPU "Disable the usage of pure CPU version of cuVSLAM" ON)
 option(CUVSLAM_LOG_ENABLE "Enable root cuvslam::Log." OFF)
-option(SOF_USE_SMALLER_NCC "Use 3-pixel area for NCC. Possible it is useful for fisheye. By default, NCC uses 5 pixels." OFF)
 option(CUVSLAM_BUILD_SHARED_LIB "Build shared library version of cuVSLAM" TRUE)
 option(USE_RERUN "Use Rerun for visualization" OFF)
 

--- a/cmake/cuVSLAMUtils.cmake
+++ b/cmake/cuVSLAMUtils.cmake
@@ -47,7 +47,6 @@ macro(setup_cuvslam_settings)
         $<$<BOOL:${CUVSLAM_LOG_ENABLE}>:CUVSLAM_LOG_ENABLE>
         $<$<BOOL:${USE_SLAM_OUTPUT}>:USE_SLAM_OUTPUT>
         $<$<BOOL:${USE_LMDB}>:USE_LMDB>
-        $<$<BOOL:${SOF_USE_SMALLER_NCC}>:SOF_USE_SMALLER_NCC>
         $<$<BOOL:${USE_NVTX}>:USE_NVTX>
         $<$<BOOL:${USE_CUDA}>:USE_CUDA>
         $<$<BOOL:${ENFORCE_GPU}>:ENFORCE_GPU>

--- a/libs/cuda_modules/cuda_kernels/cuda_common.h
+++ b/libs/cuda_modules/cuda_kernels/cuda_common.h
@@ -26,11 +26,7 @@
 #define BLOCK_WIDTH 32
 #define BLOCK_HEIGHT 8
 
-#ifdef SOF_USE_SMALLER_NCC
-#define NCC_DIM 3
-#else
 #define NCC_DIM 5
-#endif
 
 namespace cuvslam::cuda {
 

--- a/libs/sof/klt_tracker.cpp
+++ b/libs/sof/klt_tracker.cpp
@@ -31,11 +31,7 @@ void KLTTracker::compute_residual(KLTTracker::FeaturePatch& residual, const KLTT
 }
 
 float KLTTracker::compute_ncc(const KLTTracker::FeaturePatch& patch1, const KLTTracker::FeaturePatch& patch2) {
-#ifdef SOF_USE_SMALLER_NCC
-  int NCC_DIM = 3;
-#else
   int NCC_DIM = 5;
-#endif
 
   assert(patch1.size() == patch2.size() && patch1.cols() == patch1.rows() && patch2.cols() == patch2.rows());
   assert(patch1.cols() >= NCC_DIM);

--- a/libs/sof/lk_tracker.cpp
+++ b/libs/sof/lk_tracker.cpp
@@ -37,11 +37,7 @@ void LKFeatureTracker::computeTGradient(LKFeatureTracker::FeaturePatch& tPatch,
 
 float LKFeatureTracker::ncc(const LKFeatureTracker::FeaturePatch& patch1,
                             const LKFeatureTracker::FeaturePatch& patch2) {
-#ifdef SOF_USE_SMALLER_NCC
-  enum { NCC_DIM = 3 };
-#else
   enum { NCC_DIM = 5 };
-#endif
 
   assert(patch1.size() == patch2.size() && patch1.cols() == patch1.rows() && patch2.cols() == patch2.rows());
   assert(patch1.cols() >= NCC_DIM);

--- a/libs/sof/st_tracker.cpp
+++ b/libs/sof/st_tracker.cpp
@@ -152,11 +152,7 @@ const cuvslam::sof::KernelOperator<FeaturePatch> gaussian_weights(
         .eval());
 
 float compute_ncc(const FeaturePatch& patch1, const FeaturePatch& patch2) {
-#ifdef SOF_USE_SMALLER_NCC
-  constexpr int NCC_DIM = 3;
-#else
   constexpr int NCC_DIM = 5;
-#endif
 
   assert(patch1.size() == patch2.size() && patch1.cols() == patch1.rows() && patch2.cols() == patch2.rows());
   assert(patch1.cols() >= NCC_DIM);


### PR DESCRIPTION
The option defaulted to OFF and nothing in the repo turned it on, so the 3-pixel NCC window it selected was never built. Every NCC_DIM already resolved to 5 in practice.

Drop the option from the root CMakeLists and from the compile definitions in setup_cuvslam_settings, and replace the four #ifdef blocks with the plain NCC_DIM = 5 they already produced, in cuda_common.h and the KLT, LK and ST tracker NCC helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Removed the option to select a smaller NCC area during builds.

- **Behavior**
  - Standardized NCC-based tracking to use a 5×5 pixel window across all supported tracking operations.
  - Removed support for the previous 3×3 pixel NCC window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->