### PR TITLE
[fix] write the edex intrinsics key as size, not resolution

### DIFF
--- a/tools/python_tools/cuvslam_tools/common/edex.py
+++ b/tools/python_tools/cuvslam_tools/common/edex.py
@@ -290,9 +290,11 @@ class EDEXMetadata:
             # Validate the header and body before writing
             new_header = EDEXHeader.model_validate(self.header.model_dump())
             new_body = EDEXBody.model_validate(self.body.model_dump())
+            # by_alias is what puts "size" in the file. Without it pydantic writes the field
+            # name "resolution", which neither the C++ nor the python reader accepts.
             data = [
-                new_header.model_dump(exclude_none=True),
-                new_body.model_dump(exclude_none=True),
+                new_header.model_dump(exclude_none=True, by_alias=True),
+                new_body.model_dump(exclude_none=True, by_alias=True),
             ]
             with open(filename, "w") as f:
                 json.dump(data, f, indent=2, cls=EDEXEncoder)

--- a/tools/python_tools/cuvslam_tools/tests/test_edex.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_edex.py
@@ -43,6 +43,21 @@ class TestEdex(unittest.TestCase):
         self.assertEqual(edex.header.cameras[0].intrinsics.resolution.shape, (2,))
         self.assertEqual(edex.header.cameras[0].transform.shape, (3, 4))
 
+    def test_write_edex_uses_size_key(self):
+        # Round tripping through EDEXMetadata accepts either spelling, so check the raw json:
+        # the C++ reader and dataset_reader.py only know "size".
+        edex = EDEXMetadata.read(DATA_DIR / "edex")
+        with tempfile.NamedTemporaryFile(
+            mode="w+", delete=True, encoding="utf-8"
+        ) as temp_file:
+            edex.write(Path(temp_file.name))
+            with open(temp_file.name) as f:
+                header = json.load(f)[0]
+
+        for camera in header["cameras"]:
+            self.assertIn("size", camera["intrinsics"])
+            self.assertNotIn("resolution", camera["intrinsics"])
+
     def test_read_edex_copy_transform(self):
         # Read the intrinsics-only EDEX file
         edex_intrinsics = EDEXMetadata.read(DATA_DIR / "edex_intrinsics")


### PR DESCRIPTION
Intrinsics.resolution is declared with alias="size", but EDEXMetadata.write dumped the models without by_alias, so pydantic serialised the field name. Every file the writer produced carried "resolution" and then failed to load in both readers: EDEX_CAM_SIZE in libs/edex/edex_internal.h, and the key check in dataset_reader.py that raises KeyError: 'size'. This hit every producer going through EDEXMetadata.write, not just the RGB-D path.

The existing round trip test missed it because the model sets populate_by_name, so reading the written file back accepts either spelling. The new test opens the raw json instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected EDEX output so camera intrinsics use the `size` field consistently.
  * Removed the legacy `resolution` field from generated EDEX JSON.

* **Tests**
  * Added coverage to verify the corrected output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->