### PR TITLE
[infra] select the evaluation suite per pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,9 @@ env:
   EVAL_REPORT_ARTIFACT: eval-reports-staging
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
   S3_DATASETS_BUCKET: ${{ vars.S3_DATASETS_BUCKET }}
+  # Nightlies carry every evaluation record. The Jetson configurations inherit
+  # this but never read it: their eval steps are gated on matrix.eval.
+  EVAL_SUITE: full
 
 jobs:
   check-changes:
@@ -197,7 +200,7 @@ jobs:
         run: |
           docker run --rm --network host \
             -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -e S3_DATASETS_BUCKET \
-            -e RUNNER_STORAGE_ROOT -e RUNNER_LOCAL_DATASETS_ROOT \
+            -e RUNNER_STORAGE_ROOT -e RUNNER_LOCAL_DATASETS_ROOT -e EVAL_SUITE \
             -v "$(pwd):/cuvslam:ro" \
             -v "$RUNNER_LOCAL_DATASETS_ROOT:$RUNNER_LOCAL_DATASETS_ROOT" \
             -w /cuvslam \
@@ -212,7 +215,7 @@ jobs:
           mkdir -p "$RUNNER_LOCAL_DATASETS_ROOT"
           docker run --rm --network host \
             -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -e S3_DATASETS_BUCKET \
-            -e RUNNER_LOCAL_DATASETS_ROOT \
+            -e RUNNER_LOCAL_DATASETS_ROOT -e EVAL_SUITE \
             -v "$(pwd):/cuvslam:ro" \
             -v "$RUNNER_LOCAL_DATASETS_ROOT:$RUNNER_LOCAL_DATASETS_ROOT" \
             -w /cuvslam \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,8 +23,8 @@ env:
   EVAL_REPORT_ARTIFACT: eval-reports-staging
   AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
   S3_DATASETS_BUCKET: ${{ vars.S3_DATASETS_BUCKET }}
-  # Nightlies carry every evaluation record. The Jetson configurations inherit
-  # this but never read it: their eval steps are gated on matrix.eval.
+  # Jetson configurations inherit this but never read it: their eval steps are
+  # gated on matrix.eval.
   EVAL_SUITE: full
 
 jobs:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -19,6 +19,11 @@ env:
   S3_DATASETS_BUCKET: ${{ vars.S3_DATASETS_BUCKET }}
   # PR eval runs on x86_64 with the build script's default CUDA/Ubuntu.
   EVAL_CONFIG: x86_64-cuda12.6.3-ubuntu24.04
+  # Pre-merge runs the cheap suite. It selects the same records as full until a
+  # full-only dataset is enabled, and its KPI values stay comparable to the
+  # nightly history this job diffs against because the shared datasets keep one
+  # reporter config, and therefore one KPI prefix, in both suites.
+  EVAL_SUITE: smoke
 
 jobs:
   lint:
@@ -149,7 +154,7 @@ jobs:
         run: |
           docker run --rm --network host \
             -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -e S3_DATASETS_BUCKET \
-            -e RUNNER_STORAGE_ROOT -e RUNNER_LOCAL_DATASETS_ROOT \
+            -e RUNNER_STORAGE_ROOT -e RUNNER_LOCAL_DATASETS_ROOT -e EVAL_SUITE \
             -v "$(pwd):/cuvslam:ro" \
             -v "$RUNNER_LOCAL_DATASETS_ROOT:$RUNNER_LOCAL_DATASETS_ROOT" \
             -w /cuvslam \
@@ -163,7 +168,7 @@ jobs:
           mkdir -p "$RUNNER_LOCAL_DATASETS_ROOT"
           docker run --rm --network host \
             -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION -e S3_DATASETS_BUCKET \
-            -e RUNNER_LOCAL_DATASETS_ROOT \
+            -e RUNNER_LOCAL_DATASETS_ROOT -e EVAL_SUITE \
             -v "$(pwd):/cuvslam:ro" \
             -v "$RUNNER_LOCAL_DATASETS_ROOT:$RUNNER_LOCAL_DATASETS_ROOT" \
             -w /cuvslam \

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -19,10 +19,6 @@ env:
   S3_DATASETS_BUCKET: ${{ vars.S3_DATASETS_BUCKET }}
   # PR eval runs on x86_64 with the build script's default CUDA/Ubuntu.
   EVAL_CONFIG: x86_64-cuda12.6.3-ubuntu24.04
-  # Pre-merge runs the cheap suite. It selects the same records as full until a
-  # full-only dataset is enabled, and its KPI values stay comparable to the
-  # nightly history this job diffs against because the shared datasets keep one
-  # reporter config, and therefore one KPI prefix, in both suites.
   EVAL_SUITE: smoke
 
 jobs:


### PR DESCRIPTION
The suite mechanism merged in #146 but no workflow chose a suite, so an unset EVAL_SUITE left every job evaluating every record.

Pick one per pipeline: nightly runs full, pre-merge runs smoke. Forward the variable into the two containerised eval steps; the third step runs eval_cuvslam_in_docker.sh on the host and inherits it from the workflow environment.

Nothing changes yet. Both suites select complete KITTI and EuRoC, so the first behavioral difference arrives with the first full-only dataset, which is what this makes possible: without it, marking a dataset full-only would have no effect and pre-merge would keep paying for nightly's coverage.

PR KPI values stay comparable to the nightly history this job diffs against, because a dataset in both suites keeps one reporter config and therefore one KPI prefix.

Timeouts are unchanged. A nightly x86 job measures about 30 minutes against a 120 minute budget, and smoke equals full today, so there is nothing to re-measure until a large corpus is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Configured nightly evaluations to use the full evaluation suite.
  - Configured pull request verification to use the smoke evaluation suite.
  - Ensured evaluation and dataset preparation steps consistently receive the selected suite configuration.
  - Improved consistency between scheduled and pull request validation runs by applying the appropriate evaluation scope throughout each workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->