### PR TITLE
[infra] offer M3ED-SPOT in the provisioning workflow

### DIFF
--- a/.github/workflows/provision-datasets.yml
+++ b/.github/workflows/provision-datasets.yml
@@ -11,6 +11,7 @@ on:
           - euroc
           - tum
           - icl_nuim
+          - m3ed_spot
           - tartan
         default: kitti
       force_download:


### PR DESCRIPTION
m3ed_spot has been provisionable since #158 but was unreachable: the dispatch input is a static choice list, so a registry entry alone does not appear in the UI.

It needs no dataset-specific image. The TartanAir toolbox image and the x86-only runner guard are selected by literal equality with 'tartan', so M3ED runs on cuvslam-ci:local, and provision_dataset.sh installs the tools package that carries its numpy, Pillow and h5py.

CODa stays unlisted. Its preparation converts archives fetched by hand, so a dispatch would fail without a pre-seeded raw directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `m3ed_spot` as a selectable dataset option when provisioning datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->