### PR TITLE
[fix] read the M3ED source from the bucket when --raw-dir is empty

### DIFF
--- a/tools/python_tools/README.md
+++ b/tools/python_tools/README.md
@@ -324,7 +324,9 @@ Unlike the other converters this one has no download step. The stereo images exi
 6% of it. The source is therefore read over HTTP range requests, so a sequence transfers roughly 3 GB instead of
 downloading 25-42 GB, and nothing is staged on disk. `--force-download` and `--download-only` are rejected for the
 same reason. Pass `--raw-dir` to read already-downloaded files instead, laid out as
-`<raw-dir>/<published-sequence>/<published-sequence>_{data,pose_gt}.h5`.
+`<raw-dir>/<published-sequence>/<published-sequence>_{data,pose_gt}.h5`. A `--raw-dir` holding none of those files
+means the bucket, since provisioning passes every dataset a directory to download into and this one has nothing to
+download; a `--raw-dir` that is not a directory is rejected rather than quietly streaming the whole corpus.
 
 Reading one object takes tens of minutes and M3ED does republish files, so every range read sends the object's ETag as
 `If-Range`. A file replaced mid-conversion answers with the whole object instead of the range, which is refused before

--- a/tools/python_tools/cuvslam_tools/dataset_preparation/m3ed_spot/prepare.py
+++ b/tools/python_tools/cuvslam_tools/dataset_preparation/m3ed_spot/prepare.py
@@ -130,6 +130,35 @@ def _open_local_factory(raw_dir: Path):
     return open_local
 
 
+def _has_source_files(raw_dir: Path) -> bool:
+    """Report whether ``raw_dir`` holds any of the published source files."""
+    return any(
+        local_path(raw_dir, published, kind).is_file()
+        for _, published in convert_m3ed_spot.SEQUENCES
+        for kind in ("data", "pose_gt")
+    )
+
+
+def _select_source(raw_dir: Optional[Path]):
+    """Return the opener for the source and a line describing it.
+
+    Provisioning creates a download directory for every dataset and passes it
+    as ``--raw-dir``, but this one has nothing to download, so a directory
+    without source files in it means the bucket. A ``--raw-dir`` that is not a
+    directory at all is a mistake rather than that contract: streaming 46 GB
+    because of a mistyped path would take hours to notice.
+    """
+    remote = f"{BUCKET_URL}/{OBJECT_PREFIX}"
+    if raw_dir is None:
+        return _open_remote, remote
+    raw_dir = Path(raw_dir)
+    if not raw_dir.is_dir():
+        raise PreparationError(f"--raw-dir is not a directory: {raw_dir}")
+    if not _has_source_files(raw_dir):
+        return _open_remote, f"{remote} ({raw_dir} holds no source files)"
+    return _open_local_factory(raw_dir), str(raw_dir)
+
+
 def prepare(
     raw_dir: Optional[Path] = None,
     output_dir: Optional[Path] = None,
@@ -141,7 +170,7 @@ def prepare(
 ) -> Path:
     """Convert the selected sequences and return the prepared root.
 
-    Reads from S3 unless ``raw_dir`` names a directory of downloaded files.
+    Reads from S3 unless ``raw_dir`` holds already-downloaded source files.
     ``sequences`` defaults to all 19 published SPOT sequences.
     """
     output_dir = resolve_output_dir(output_dir)
@@ -157,12 +186,8 @@ def prepare(
         # cached between runs, so every conversion already re-reads the source.
         print("note: --force-download has no effect; the source is never cached locally")
 
-    if raw_dir is not None:
-        opener = _open_local_factory(Path(raw_dir))
-        print(f"Source     : {raw_dir}")
-    else:
-        opener = _open_remote
-        print(f"Source     : {BUCKET_URL}/{OBJECT_PREFIX}")
+    opener, source = _select_source(raw_dir)
+    print(f"Source     : {source}")
     print(f"Output dir : {output_dir}")
     print()
 

--- a/tools/python_tools/cuvslam_tools/tests/test_m3ed_preparation.py
+++ b/tools/python_tools/cuvslam_tools/tests/test_m3ed_preparation.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA software released under the NVIDIA Community License is intended to be used to enable
+# the further development of AI and robotics technologies. Such software has been designed, tested,
+# and optimized for use with NVIDIA hardware, and this License grants permission to use the software
+# solely with such hardware.
+# Subject to the terms of this License, NVIDIA confirms that you are free to commercially use,
+# modify, and distribute the software with NVIDIA hardware. NVIDIA does not claim ownership of any
+# outputs generated using the software or derivative works thereof. Any code contributions that you
+# share with NVIDIA are licensed to NVIDIA as feedback under this License and may be incorporated
+# in future releases without notice or attribution.
+# By using, reproducing, modifying, distributing, performing, or displaying any portion or element
+# of the software or derivative works thereof, you agree to be bound by this License.
+
+"""Where prepare_m3ed_spot reads its source from.
+
+M3ED is the only corpus with no download step, so it has to reconcile that with
+a provisioning contract that hands every dataset a directory to download into.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from cuvslam_tools.dataset_preparation.common import PreparationError
+from cuvslam_tools.dataset_preparation.m3ed_spot import convert_m3ed_spot, prepare
+
+
+class TestSourceSelection(unittest.TestCase):
+    def setUp(self):
+        self._temporary = tempfile.TemporaryDirectory()
+        self.raw = Path(self._temporary.name)
+
+    def tearDown(self):
+        self._temporary.cleanup()
+
+    def _download(self, sequence, kind="data"):
+        path = prepare.local_path(self.raw, convert_m3ed_spot.source_name(sequence), kind)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"not really HDF5")
+        return path
+
+    def test_no_raw_dir_reads_the_bucket(self):
+        opener, source = prepare._select_source(None)
+        self.assertIs(opener, prepare._open_remote)
+        self.assertIn(prepare.BUCKET_URL, source)
+
+    def test_an_empty_raw_dir_reads_the_bucket(self):
+        # provision_dataset.sh creates this directory and passes it for every
+        # dataset. Reading it as a source made provisioning fail on the first
+        # sequence, looking for files that this converter never downloads.
+        opener, source = prepare._select_source(self.raw)
+        self.assertIs(opener, prepare._open_remote)
+        self.assertIn("no source files", source)
+
+    def test_downloaded_files_are_read_when_they_are_there(self):
+        self._download("skatepark_2")
+        opener, source = prepare._select_source(self.raw)
+        self.assertIsNot(opener, prepare._open_remote)
+        self.assertEqual(source, str(self.raw))
+
+    def test_a_raw_dir_that_is_not_a_directory_is_rejected(self):
+        # Not the provisioning contract but a typo, and streaming the whole
+        # corpus instead would take hours to notice.
+        with self.assertRaisesRegex(PreparationError, "not a directory"):
+            prepare._select_source(self.raw / "absent")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
provision_dataset.sh creates a download directory for every dataset and passes it as --raw-dir, which the registry forwards verbatim. M3ED read any raw_dir as "the sources are already downloaded here", so the first provisioning run of it went local against an empty scratch directory and failed on the first sequence looking for a file it never downloads.

A --raw-dir holding none of the published files now means the bucket, the same way --force-download is accepted and has no effect: this converter has nothing to download, so an empty directory cannot be a source. A --raw-dir that is not a directory stays an error, because streaming 70 GB because of a mistyped path would take hours to notice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * M3ED SPOT preparation now uses available local HDF5 files when a valid directory contains the required source data.
  * Empty directories automatically fall back to streaming source data remotely.
  * Invalid non-directory paths are rejected with a preparation error.

* **Documentation**
  * Clarified local HDF5 directory requirements and `--raw-dir` behavior.

* **Tests**
  * Added coverage for local sources, remote fallback, empty directories, and invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->