### PR TITLE
[fix] retry the provisioning tar instead of discarding the archive

### DIFF
--- a/scripts/provision_dataset.sh
+++ b/scripts/provision_dataset.sh
@@ -104,18 +104,33 @@ fi
 
 echo "=== Creating tarball from $upload_src ==="
 echo "Archiving ${file_count} files"
-sync
-tar_rc=0
-tar -C "$upload_src" -cf "$tarball" \
-  --warning=no-file-changed \
-  --checkpoint=1000 \
-  --checkpoint-action=echo='tar checkpoint %d' \
-  --totals \
-  . || tar_rc=$?
-if [ "$tar_rc" -ne 0 ]; then
-  echo "Error: tar failed with exit code $tar_rc" >&2
-  exit 1
-fi
+# Exit 1 means a file changed while being archived, so the tarball is not a
+# faithful copy of the tree. Conversion has finished by now and nothing else
+# writes here, so a single race does not repeat: archive again rather than
+# discard hours of conversion. Anything above 1 is a hard error that a retry
+# cannot fix.
+#
+# The file-changed warning stays on. It was suppressed while two runs shared
+# one $RUNNER_TEMP/provision-work, which per-run directories then fixed; since
+# then it only hid which file tar was complaining about.
+for attempt in 1 2; do
+  sync
+  tar_rc=0
+  tar -C "$upload_src" -cf "$tarball" \
+    --checkpoint=1000 \
+    --checkpoint-action=echo='tar checkpoint %d' \
+    --totals \
+    . || tar_rc=$?
+  if [ "$tar_rc" -eq 0 ]; then
+    break
+  fi
+  if [ "$tar_rc" -ne 1 ] || [ "$attempt" -eq 2 ]; then
+    echo "Error: tar failed with exit code $tar_rc on attempt $attempt" >&2
+    exit 1
+  fi
+  echo "Warning: tar reported a file changed while archiving; archiving again" >&2
+  rm -f "$tarball"
+done
 ls -lh "$tarball"
 
 if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
The first real m3ed_spot provisioning run wrote all 56 GiB of its tarball, byte for byte what the successful dry run wrote, and then exited 1. Under --create that exit code means a file changed while being archived, so the script treated it as fatal and threw away four hours of conversion at the last step.

Exit 1 is worth one more attempt. Conversion has finished by then and nothing else writes into the work directory, so a single race does not repeat; re-archiving costs nine minutes against re-converting from scratch. Anything above 1 is a hard error and still fails at once.

The file-changed warning stops being suppressed. It was silenced in e56c4df, whose real fix was giving each run its own $RUNNER_TEMP/provision-work-$GITHUB_RUN_ID: two runs had been sharing one directory, so one really was mutating the tree another was archiving. That cause is gone, and per-dataset concurrency guards it besides, while suppression left us unable to see which file tar meant.

Validated against a 321 MiB tree, since scripts/ carries no tests: clean tree archives in one attempt; a tar stub exiting 1 then 0 retries once and proceeds; exiting 1 twice fails with "exit code 1 on attempt 2"; an unwritable target makes real tar exit 2 and fails without a retry. bash -n and pre-commit are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dataset archive creation now retries once when files change during archiving.
  - Preserves archive warnings while preventing incomplete archives from being retained.
  - Other archive failures, or a second failed attempt, are still reported as errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->